### PR TITLE
Make types generated for Rust automatically derive a couple of traits

### DIFF
--- a/src/generate_rust.rs
+++ b/src/generate_rust.rs
@@ -12,6 +12,9 @@ use std::{
 // The string to be used for each indentation level.
 const INDENTATION: &str = "    ";
 
+// Any generated types will derive these traits.
+const TRAITS_TO_DERIVE: &[&str] = &["Clone", "Debug"];
+
 // This struct represents a tree of schemas organized in a module hierarchy.
 #[derive(Clone, Debug)]
 struct Module {
@@ -172,8 +175,10 @@ fn render_struct(
     let indentation_str = (0..indentation).map(|_| INDENTATION).collect::<String>();
 
     format!(
-        "{}#[allow(dead_code)]\n{}pub struct {} {{\n{}{}}}\n",
+        "{}#[allow(dead_code)]\n{}#[derive({})]\n{}pub struct {} {{\n{}{}}}\n",
         indentation_str,
+        indentation_str,
+        TRAITS_TO_DERIVE.join(", "),
         indentation_str,
         pascal_case(name),
         fields
@@ -196,8 +201,10 @@ fn render_choice(
     let indentation_str = (0..indentation).map(|_| INDENTATION).collect::<String>();
 
     format!(
-        "{}#[allow(dead_code)]\n{}pub enum {} {{\n{}{}}}\n",
+        "{}#[allow(dead_code)]\n{}#[derive({})]\n{}pub enum {} {{\n{}{}}}\n",
         indentation_str,
+        indentation_str,
+        TRAITS_TO_DERIVE.join(", "),
         indentation_str,
         pascal_case(name),
         fields

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -10,7 +10,7 @@ pub struct Schema {
     pub declarations: Vec<Declaration>,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Namespace {
     // This is a representation of a path to a schema, relative to the base directory, i.e., the
     // parent of the schema path provided by the user. However, it differs from paths as follows:


### PR DESCRIPTION
Make types generated for Rust automatically derive a couple of traits.

**Status:** Ready

**Fixes:** N/A
