### PR TITLE
Add a helpful Tagref reference to the `path_to_namespace` function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,7 @@ fn path_to_namespace(path: &Path) -> schema::Namespace {
         components: path
             .components()
             .map(|component| match component {
+                // [ref:names_unique_after_normalization]
                 Component::Normal(component) => snake_case(&component.to_string_lossy()),
                 _ => panic!(),
             })


### PR DESCRIPTION
Add a helpful Tagref reference to the `path_to_namespace` function.

**Status:** Ready

**Fixes:** N/A
