### PR TITLE
Add support for a primitive type: `Bool`

### DIFF
--- a/integration/types/basic/bool.t
+++ b/integration/types/basic/bool.t
@@ -1,7 +1,0 @@
-import 'unit.t' as unit
-
-# The familiar Boolean type
-choice Bool {
-  false: unit.Unit = 0
-  true: unit.Unit = 1
-}

--- a/integration/types/basic/void.t
+++ b/integration/types/basic/void.t
@@ -1,0 +1,3 @@
+# A trivial choice with no variants
+struct Void {
+}

--- a/integration/types/main.t
+++ b/integration/types/main.t
@@ -1,13 +1,16 @@
-import 'basic/bool.t' as bool
+import 'basic/unit.t' as unit
+import 'basic/void.t' as void
 
 struct Foo {
-  x: bool.Bool = 0
-  y: bool.Bool = 1
-  z: restricted bool.Bool = 2
+  x: unit.Unit = 0
+  y: void.Void = 1
+  z: restricted unit.Unit = 2
+  w: Bool = 3
 }
 
 choice Bar {
-  x: bool.Bool = 0
-  y: bool.Bool = 1
-  z: restricted bool.Bool = 2
+  x: unit.Unit = 0
+  y: void.Void = 1
+  z: restricted unit.Unit = 2
+  w: Bool = 3
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -6,6 +6,7 @@ use std::{
 
 // Keywords
 pub const AS_KEYWORD: &str = "as";
+pub const BOOL_KEYWORD: &str = "Bool";
 pub const CHOICE_KEYWORD: &str = "choice";
 pub const IMPORT_KEYWORD: &str = "import";
 pub const RESTRICTED_KEYWORD: &str = "restricted";
@@ -23,11 +24,12 @@ pub struct Token {
 #[derive(Clone, Debug)]
 pub enum Variant {
     As,
+    Bool,
     Choice,
     Colon,
     Dot,
     Equals,
-    Identifier(String), // Non-empty [tag:identifier_non_empty]
+    Identifier(String),
     Import,
     Integer(usize),
     LeftCurly,
@@ -47,6 +49,7 @@ impl Display for Variant {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
             Self::As => write!(f, "{}", AS_KEYWORD),
+            Self::Bool => write!(f, "{}", BOOL_KEYWORD),
             Self::Choice => write!(f, "{}", CHOICE_KEYWORD),
             Self::Colon => write!(f, ":"),
             Self::Dot => write!(f, "."),
@@ -68,8 +71,8 @@ mod tests {
     use crate::{
         error::SourceRange,
         token::{
-            Token, Variant, AS_KEYWORD, CHOICE_KEYWORD, IMPORT_KEYWORD, RESTRICTED_KEYWORD,
-            STRUCT_KEYWORD,
+            Token, Variant, AS_KEYWORD, BOOL_KEYWORD, CHOICE_KEYWORD, IMPORT_KEYWORD,
+            RESTRICTED_KEYWORD, STRUCT_KEYWORD,
         },
     };
     use std::path::Path;
@@ -91,6 +94,11 @@ mod tests {
     #[test]
     fn variant_as_display() {
         assert_eq!(format!("{}", Variant::As), AS_KEYWORD);
+    }
+
+    #[test]
+    fn variant_bool_display() {
+        assert_eq!(format!("{}", Variant::Bool), BOOL_KEYWORD);
     }
 
     #[test]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -2,8 +2,8 @@ use crate::{
     error::{listing, throw, Error, SourceRange},
     format::CodeStr,
     token::{
-        Token, Variant, AS_KEYWORD, CHOICE_KEYWORD, IMPORT_KEYWORD, RESTRICTED_KEYWORD,
-        STRUCT_KEYWORD,
+        Token, Variant, AS_KEYWORD, BOOL_KEYWORD, CHOICE_KEYWORD, IMPORT_KEYWORD,
+        RESTRICTED_KEYWORD, STRUCT_KEYWORD,
     },
 };
 use std::path::Path;
@@ -93,6 +93,11 @@ pub fn tokenize(schema_path: &Path, schema_contents: &str) -> Result<Vec<Token>,
                     tokens.push(Token {
                         source_range: SourceRange { start: i, end },
                         variant: Variant::As,
+                    });
+                } else if &schema_contents[i..end] == BOOL_KEYWORD {
+                    tokens.push(Token {
+                        source_range: SourceRange { start: i, end },
+                        variant: Variant::Bool,
                     });
                 } else if &schema_contents[i..end] == CHOICE_KEYWORD {
                     tokens.push(Token {
@@ -253,8 +258,8 @@ mod tests {
         assert_fails, assert_same,
         error::SourceRange,
         token::{
-            Token, Variant, AS_KEYWORD, CHOICE_KEYWORD, IMPORT_KEYWORD, RESTRICTED_KEYWORD,
-            STRUCT_KEYWORD,
+            Token, Variant, AS_KEYWORD, BOOL_KEYWORD, CHOICE_KEYWORD, IMPORT_KEYWORD,
+            RESTRICTED_KEYWORD, STRUCT_KEYWORD,
         },
         tokenizer::tokenize,
     };
@@ -559,6 +564,20 @@ mod tests {
                     end: AS_KEYWORD.len(),
                 },
                 variant: Variant::As,
+            }],
+        );
+    }
+
+    #[test]
+    fn tokenize_bool() {
+        assert_same!(
+            tokenize(Path::new("foo.t"), BOOL_KEYWORD).unwrap(),
+            vec![Token {
+                source_range: SourceRange {
+                    start: 0,
+                    end: BOOL_KEYWORD.len(),
+                },
+                variant: Variant::Bool,
             }],
         );
     }


### PR DESCRIPTION
Add support for a primitive type: `Bool`. A user could already construct a Boolean type with `choice`, but this new type is special (more ergonomic and more efficient) because it maps to the native Boolean type of the host language.

**Status:** Ready

**Fixes:** N/A
