### PR TITLE
Use encapsulation for the `Identifier` type to achieve information hiding and invariant enforcement

### DIFF
--- a/src/naming_conventions.rs
+++ b/src/naming_conventions.rs
@@ -53,12 +53,12 @@ pub fn pascal_case(name: &str) -> String {
 
 // This function converts an identifier to `snake_case`.
 pub fn snake_case_id(identifier: &Identifier) -> String {
-    snake_case(&identifier.case_folded)
+    snake_case(&identifier.original())
 }
 
 // This function converts an identifier to `PascalCase`.
 pub fn pascal_case_id(identifier: &Identifier) -> String {
-    pascal_case(&identifier.case_folded)
+    pascal_case(&identifier.original())
 }
 
 #[cfg(test)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -103,7 +103,7 @@ impl Display for Schema {
                 f,
                 "import '{}' as {}",
                 import.path.display(),
-                import.name.original,
+                import.name.original(),
             )?;
         }
 
@@ -131,7 +131,7 @@ impl Display for DeclarationVariant {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             Self::Struct(name, fields) => {
-                writeln!(f, "struct {} {{", name.original)?;
+                writeln!(f, "struct {} {{", name.original())?;
 
                 for field in fields.iter() {
                     writeln!(f, "{}", field)?;
@@ -142,7 +142,7 @@ impl Display for DeclarationVariant {
                 Ok(())
             }
             Self::Choice(name, fields) => {
-                writeln!(f, "choice {} {{", name.original)?;
+                writeln!(f, "choice {} {{", name.original())?;
 
                 for field in fields.iter() {
                     writeln!(f, "{}", field)?;
@@ -162,13 +162,17 @@ impl Display for Field {
             write!(
                 f,
                 "  {}: transitional {} = {}",
-                self.name.original, self.r#type, self.index,
+                self.name.original(),
+                self.r#type,
+                self.index,
             )?;
         } else {
             write!(
                 f,
                 "  {}: {} = {}",
-                self.name.original, self.r#type, self.index,
+                self.name.original(),
+                self.r#type,
+                self.index,
             )?;
         }
 
@@ -191,9 +195,9 @@ impl Display for TypeVariant {
             }
             Self::Custom(import, name) => {
                 if let Some(import) = import {
-                    write!(f, "{}.{}", import.original, name.original)?;
+                    write!(f, "{}.{}", import.original(), name.original())?;
                 } else {
-                    write!(f, "{}", name.original)?;
+                    write!(f, "{}", name.original())?;
                 }
             }
         }
@@ -208,7 +212,7 @@ impl Display for Namespace {
             "{}",
             self.components
                 .iter()
-                .map(|component| component.original.as_str())
+                .map(Identifier::original)
                 .collect::<Vec<_>>()
                 .join("."),
         )?;

--- a/src/token.rs
+++ b/src/token.rs
@@ -28,8 +28,8 @@ pub struct Token {
 // generated code without case conversion.
 #[derive(Clone, Debug)]
 pub struct Identifier {
-    pub original: String,
-    pub case_folded: String,
+    original: String,
+    case_folded: String,
 }
 
 impl PartialEq for Identifier {
@@ -64,6 +64,12 @@ impl From<&str> for Identifier {
             original: string.to_owned(),
             case_folded: snake_case(string),
         }
+    }
+}
+
+impl Identifier {
+    pub fn original(&self) -> &str {
+        &self.original
     }
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,10 +1,9 @@
 use crate::{
     error::{listing, throw, Error, SourceRange},
     format::CodeStr,
-    naming_conventions::snake_case,
     token::{
-        Identifier, Token, Variant, AS_KEYWORD, BOOL_KEYWORD, CHOICE_KEYWORD, IMPORT_KEYWORD,
-        STRUCT_KEYWORD, TRANSITIONAL_KEYWORD,
+        Token, Variant, AS_KEYWORD, BOOL_KEYWORD, CHOICE_KEYWORD, IMPORT_KEYWORD, STRUCT_KEYWORD,
+        TRANSITIONAL_KEYWORD,
     },
 };
 use std::path::Path;
@@ -137,10 +136,7 @@ pub fn tokenize(schema_path: &Path, schema_contents: &str) -> Result<Vec<Token>,
 
                     tokens.push(Token {
                         source_range: SourceRange { start: i, end },
-                        variant: Variant::Identifier(Identifier {
-                            original: schema_contents[start..end].to_owned(),
-                            case_folded: snake_case(&schema_contents[start..end]).to_owned(),
-                        }),
+                        variant: Variant::Identifier(schema_contents[start..end].into()),
                     });
                 }
             }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -44,7 +44,7 @@ pub fn validate(
                 errors.push(throw::<Error>(
                     &format!(
                         "An import named {} already exists in this file.",
-                        import.name.original.code_str(),
+                        import.name.original().code_str(),
                     ),
                     Some(source_path),
                     Some(&listing(source_contents, import.source_range)),
@@ -65,7 +65,7 @@ pub fn validate(
                         errors.push(throw::<Error>(
                             &format!(
                                 "A declaration named {} already exists in this file.",
-                                name.original.code_str(),
+                                name.original().code_str(),
                             ),
                             Some(source_path),
                             Some(&listing(source_contents, declaration.source_range)),
@@ -83,7 +83,7 @@ pub fn validate(
                             errors.push(throw::<Error>(
                                 &format!(
                                     "A field named {} already exists in this declaration.",
-                                    field.name.original.code_str(),
+                                    field.name.original().code_str(),
                                 ),
                                 Some(source_path),
                                 Some(&listing(source_contents, field.source_range)),
@@ -116,7 +116,7 @@ pub fn validate(
                                         errors.push(throw::<Error>(
                                             &format!(
                                                 "There is no import named {} in this file.",
-                                                import.original.code_str(),
+                                                import.original().code_str(),
                                             ),
                                             Some(source_path),
                                             Some(&listing(
@@ -138,13 +138,13 @@ pub fn validate(
                                         &if let Some(import) = import {
                                             format!(
                                                 "There is no type named {} in import {}.",
-                                                name.original.code_str(),
-                                                import.original.code_str(),
+                                                name.original().code_str(),
+                                                import.original().code_str(),
                                             )
                                         } else {
                                             format!(
                                                 "There is no type named {} in this file.",
-                                                name.original.code_str(),
+                                                name.original().code_str(),
                                             )
                                         },
                                         Some(source_path),


### PR DESCRIPTION
Use encapsulation for the `Identifier` type to achieve information hiding and invariant enforcement.

**Status:** Ready

**Fixes:** N/A
