### PR TITLE
Remove extra trailing commas that were previously needed to satisfy the trailing comma lint check

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -99,7 +99,7 @@ mod tests {
                 Error { message: \"bar\", reason: None }, \
                 Error { message: \"baz\", reason: None }\
             ].\
-        " // ,
+        "
     )]
     fn assert_fails_mismatch() {
         let success: Result<usize, Vec<Error>> = Err(vec![

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -92,7 +92,7 @@ macro_rules! consume_token_0 {
         $position:expr,
         $errors:ident,
         $variant:ident,
-        $error_value:expr $(,)? // This comma is needed to satisfy the trailing commas check: ,
+        $error_value:expr $(,)?
     ) => {{
         // Macros are call-by-name, but we want call-by-value (or at least call-by-need) to avoid
         // accidentally evaluating arguments multiple times. Here we force eager evaluation.
@@ -143,7 +143,7 @@ macro_rules! consume_token_1 {
         $errors:ident,
         $variant:ident,
         $expectation:expr,
-        $error_value:expr $(,)? // This comma is needed to satisfy the trailing commas check: ,
+        $error_value:expr $(,)?
     ) => {{
         // Macros are call-by-name, but we want call-by-value (or at least call-by-need) to avoid
         // accidentally evaluating arguments multiple times. Here we force eager evaluation.


### PR DESCRIPTION
Remove extra trailing commas that were previously needed to satisfy the trailing comma lint check.

**Status:** Ready

**Fixes:** N/A
