### PR TITLE
Switch to using bijective little-endian prefix varints instead of regular LEB128 varints

### DIFF
--- a/integration-tests/rust/src/main.rs
+++ b/integration-tests/rust/src/main.rs
@@ -1,19 +1,17 @@
 #![deny(clippy::all, clippy::pedantic, warnings)]
 
-#[macro_use]
 mod types;
 
 use {
     std::{
         f64::consts::PI,
         fmt::Debug,
-        io::{self, Error, ErrorKind, Read, Write},
-        mem::size_of,
+        io::{self, Error, ErrorKind},
     },
     types::{Deserialize, Serialize},
 };
 
-fn round_trip_message<T: Debug + Deserialize + PartialEq + Serialize>(x: &T) -> io::Result<()> {
+fn round_trip<T: Debug + Deserialize + PartialEq + Serialize>(x: &T) -> io::Result<()> {
     println!("Value to be serialized: {:?}", x);
 
     let mut buffer = Vec::<u8>::new();
@@ -30,34 +28,16 @@ fn round_trip_message<T: Debug + Deserialize + PartialEq + Serialize>(x: &T) -> 
     }
 }
 
-fn round_trip_varint(x: u64) -> io::Result<()> {
-    println!("Value to be serialized: {:?}", x);
-
-    let mut buffer = Vec::<u8>::new();
-    write_varint!(&mut buffer, x, u64)?;
-    println!("Bytes from serialization: {:?}", buffer);
-
-    let y = read_varint!(&mut buffer.as_slice(), u64)?;
-    println!("Value deserialized from those bytes: {:?}", y);
-
-    if y == x {
-        Ok(())
-    } else {
-        Err(Error::new(ErrorKind::Other, "Mismatch!"))
-    }
-}
-
-#[allow(clippy::float_cmp, clippy::shadow_unrelated)]
 fn main() -> io::Result<()> {
-    round_trip_message::<f64>(&PI)?;
+    round_trip::<bool>(&false)?;
     println!();
-    round_trip_message::<bool>(&false)?;
+    round_trip::<bool>(&true)?;
     println!();
-    round_trip_message::<bool>(&true)?;
+    round_trip::<u64>(&u64::MIN)?;
     println!();
-    round_trip_varint(u64::MIN)?;
+    round_trip::<u64>(&u64::MAX)?;
     println!();
-    round_trip_varint(u64::MAX)?;
+    round_trip::<f64>(&PI)?;
 
     Ok(())
 }


### PR DESCRIPTION
Switch to using bijective little-endian prefix varints instead of regular LEB128 varints.

**Status:** Ready

**Fixes:** N/A
