### PR TITLE
Remove an extraneous line break that would sometimes be emitted by the Rust code generator

### DIFF
--- a/src/generate_rust.rs
+++ b/src/generate_rust.rs
@@ -504,7 +504,9 @@ fn write_schema<T: Write>(
                     write_type(buffer, &imports, namespace, &field.r#type, InOrOut(In))?;
                     writeln!(buffer, "> = None;")?;
                 }
-                writeln!(buffer)?;
+                if !fields.is_empty() {
+                    writeln!(buffer)?;
+                }
                 write_indentation(buffer, indentation + 2)?;
                 writeln!(buffer, "loop {{")?;
                 write_indentation(buffer, indentation + 3)?;
@@ -1502,7 +1504,6 @@ pub mod basic {
             where
                 Self: Sized,
             {
-
                 loop {
                     let header = match u64::deserialize(reader.by_ref()) {
                         Ok(header) => header,


### PR DESCRIPTION
Remove an extraneous line break that would sometimes be emitted by the Rust code generator.

**Status:** Ready

**Fixes:** N/A
