### PR TITLE
Switch the convention to use lowercase type names in schemas

### DIFF
--- a/integration-tests/types/basic/unit.t
+++ b/integration-tests/types/basic/unit.t
@@ -1,3 +1,3 @@
 # A trivial struct with no fields
-struct Unit {
+struct unit {
 }

--- a/integration-tests/types/basic/void.t
+++ b/integration-tests/types/basic/void.t
@@ -1,3 +1,3 @@
 # A trivial choice with no variants
-choice Void {
+choice void {
 }

--- a/integration-tests/types/main.t
+++ b/integration-tests/types/main.t
@@ -1,42 +1,42 @@
 import 'basic/unit.t' as unit
 import 'basic/void.t' as void
 
-struct Foo {
-  x: Boolean = 0
-  y: unstable Boolean = 1
-  z: void.Void = 2
-  w: unstable void.Void = 3
-  s: unit.Unit = 4
-  t: unstable unit.Unit = 5
+struct foo {
+  x: bool = 0
+  y: unstable bool = 1
+  z: void.void = 2
+  w: unstable void.void = 3
+  s: unit.unit = 4
+  t: unstable unit.unit = 5
 }
 
-choice Bar {
-  x: Boolean = 0
-  y: unstable Float64 = 1
-  z: void.Void = 2
-  w: unstable void.Void = 3
-  s: unit.Unit = 4
-  t: unstable unit.Unit = 5
+choice bar {
+  x: bool = 0
+  y: unstable f64 = 1
+  z: void.void = 2
+  w: unstable void.void = 3
+  s: unit.unit = 4
+  t: unstable unit.unit = 5
 }
 
-struct FooAndBar {
-  foo: Foo = 0
-  bar: Bar = 1
+struct foo_and_bar {
+  foo: foo = 0
+  bar: bar = 1
 }
 
-choice FooOrBar {
-  foo: Foo = 0
-  bar: Bar = 1
+choice foo_or_bar {
+  foo: foo = 0
+  bar: bar = 1
 }
 
-struct Baz {
-  x: Boolean = 0
-  y: Unsigned64 = 1
-  z: Float64 = 2
+struct baz {
+  x: bool = 0
+  y: u64 = 1
+  z: f64 = 2
 }
 
-choice Qux {
-  x: Boolean = 0
-  y: Bytes = 1
-  z: unstable Float64 = 2
+choice qux {
+  x: bool = 0
+  y: bytes = 1
+  z: unstable f64 = 2
 }

--- a/src/generate_rust.rs
+++ b/src/generate_rust.rs
@@ -1120,16 +1120,16 @@ fn write_type<T: Write>(
     flavor: ChoiceFlavor,
 ) -> Result<(), fmt::Error> {
     match &r#type.variant {
-        schema::TypeVariant::Boolean => {
+        schema::TypeVariant::Bool => {
             write!(buffer, "bool")?;
         }
-        schema::TypeVariant::Float64 => {
+        schema::TypeVariant::F64 => {
             write!(buffer, "f64")?;
         }
         schema::TypeVariant::Bytes => {
             write!(buffer, "Vec<u8>")?;
         }
-        schema::TypeVariant::Unsigned64 => {
+        schema::TypeVariant::U64 => {
             write!(buffer, "u64")?;
         }
         schema::TypeVariant::Custom(import, name) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -561,12 +561,12 @@ fn parse_field(
 
     // Parse the type.
     let type_start = *position;
-    let r#type = if let token::Variant::Boolean = tokens[*position].variant {
+    let r#type = if let token::Variant::Bool = tokens[*position].variant {
         *position += 1;
 
         schema::Type {
             source_range: span_tokens(tokens, type_start, *position),
-            variant: schema::TypeVariant::Boolean,
+            variant: schema::TypeVariant::Bool,
         }
     } else if let token::Variant::Bytes = tokens[*position].variant {
         *position += 1;
@@ -575,19 +575,19 @@ fn parse_field(
             source_range: span_tokens(tokens, type_start, *position),
             variant: schema::TypeVariant::Bytes,
         }
-    } else if let token::Variant::Float64 = tokens[*position].variant {
+    } else if let token::Variant::F64 = tokens[*position].variant {
         *position += 1;
 
         schema::Type {
             source_range: span_tokens(tokens, type_start, *position),
-            variant: schema::TypeVariant::Float64,
+            variant: schema::TypeVariant::F64,
         }
-    } else if let token::Variant::Unsigned64 = tokens[*position].variant {
+    } else if let token::Variant::U64 = tokens[*position].variant {
         *position += 1;
 
         schema::Type {
             source_range: span_tokens(tokens, type_start, *position),
-            variant: schema::TypeVariant::Unsigned64,
+            variant: schema::TypeVariant::U64,
         }
     } else {
         let (import_name, r#type_name) = if *position < tokens.len() - 2 {
@@ -717,17 +717,17 @@ mod tests {
             import 'qux.t' as qux
 
             # This is a struct.
-            struct Foo {
-              x: baz.Baz = 0
-              y: unstable Unsigned64 = 1
-              z: Boolean = 2
+            struct foo {
+              x: baz.baz = 0
+              y: unstable u64 = 1
+              z: bool = 2
             }
 
             # This is a choice.
-            choice Bar {
-              x: qux.Qux = 0
-              y: unstable Bytes = 1
-              z: Float64 = 2
+            choice bar {
+              x: qux.qux = 0
+              y: unstable bytes = 1
+              z: f64 = 2
             }
         ";
         let tokens = tokenize(source_path, source).unwrap();
@@ -765,39 +765,39 @@ mod tests {
                         start: 144,
                         end: 151,
                     },
-                    variant: schema::TypeVariant::Custom(Some("baz".into()), "Baz".into()),
+                    variant: schema::TypeVariant::Custom(Some("baz".into()), "baz".into()),
                 },
                 index: 0,
             },
             schema::Field {
                 source_range: SourceRange {
                     start: 170,
-                    end: 196,
+                    end: 189,
                 },
                 name: "y".into(),
                 unstable: true,
                 r#type: schema::Type {
                     source_range: SourceRange {
                         start: 182,
-                        end: 192,
+                        end: 185,
                     },
-                    variant: schema::TypeVariant::Unsigned64,
+                    variant: schema::TypeVariant::U64,
                 },
                 index: 1,
             },
             schema::Field {
                 source_range: SourceRange {
-                    start: 211,
-                    end: 225,
+                    start: 204,
+                    end: 215,
                 },
                 name: "z".into(),
                 unstable: false,
                 r#type: schema::Type {
                     source_range: SourceRange {
-                        start: 214,
-                        end: 221,
+                        start: 207,
+                        end: 211,
                     },
-                    variant: schema::TypeVariant::Boolean,
+                    variant: schema::TypeVariant::Bool,
                 },
                 index: 2,
             },
@@ -806,31 +806,31 @@ mod tests {
         let bar_fields = vec![
             schema::Field {
                 source_range: SourceRange {
-                    start: 312,
-                    end: 326,
+                    start: 302,
+                    end: 316,
                 },
                 name: "x".into(),
                 unstable: false,
                 r#type: schema::Type {
                     source_range: SourceRange {
-                        start: 315,
-                        end: 322,
+                        start: 305,
+                        end: 312,
                     },
-                    variant: schema::TypeVariant::Custom(Some("qux".into()), "Qux".into()),
+                    variant: schema::TypeVariant::Custom(Some("qux".into()), "qux".into()),
                 },
                 index: 0,
             },
             schema::Field {
                 source_range: SourceRange {
-                    start: 341,
-                    end: 362,
+                    start: 331,
+                    end: 352,
                 },
                 name: "y".into(),
                 unstable: true,
                 r#type: schema::Type {
                     source_range: SourceRange {
-                        start: 353,
-                        end: 358,
+                        start: 343,
+                        end: 348,
                     },
                     variant: schema::TypeVariant::Bytes,
                 },
@@ -838,17 +838,17 @@ mod tests {
             },
             schema::Field {
                 source_range: SourceRange {
-                    start: 377,
-                    end: 391,
+                    start: 367,
+                    end: 377,
                 },
                 name: "z".into(),
                 unstable: false,
                 r#type: schema::Type {
                     source_range: SourceRange {
-                        start: 380,
-                        end: 387,
+                        start: 370,
+                        end: 373,
                     },
-                    variant: schema::TypeVariant::Float64,
+                    variant: schema::TypeVariant::F64,
                 },
                 index: 2,
             },
@@ -857,22 +857,22 @@ mod tests {
         let mut declarations = BTreeMap::new();
 
         declarations.insert(
-            "Foo".into(),
+            "foo".into(),
             schema::Declaration {
                 source_range: SourceRange {
                     start: 114,
-                    end: 239,
+                    end: 229,
                 },
                 variant: schema::DeclarationVariant::Struct(foo_fields),
             },
         );
 
         declarations.insert(
-            "Bar".into(),
+            "bar".into(),
             schema::Declaration {
                 source_range: SourceRange {
-                    start: 285,
-                    end: 405,
+                    start: 275,
+                    end: 391,
                 },
                 variant: schema::DeclarationVariant::Choice(bar_fields),
             },
@@ -906,17 +906,17 @@ mod tests {
     fn parse_duplicate_declaration() {
         let source_path = Path::new("foo.t");
         let source = "
-            struct Foo {
+            struct foo {
             }
 
-            choice Foo {
+            choice foo {
             }
         ";
         let tokens = tokenize(source_path, source).unwrap();
 
         assert_fails!(
             parse(source_path, source, &tokens[..]),
-            "A declaration named `Foo` already exists in this file.",
+            "A declaration named `foo` already exists in this file.",
         );
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -47,10 +47,10 @@ pub struct Type {
 
 #[derive(Clone, Debug)]
 pub enum TypeVariant {
-    Boolean,
+    Bool,
     Bytes,
-    Float64,
-    Unsigned64,
+    F64,
+    U64,
     Custom(Option<Identifier>, Identifier), // (import, name)
 }
 
@@ -173,17 +173,17 @@ impl Type {
 impl TypeVariant {
     fn write<W: Write>(&self, f: &mut W) -> fmt::Result {
         match self {
-            Self::Boolean => {
-                write!(f, "Boolean")?;
+            Self::Bool => {
+                write!(f, "bool")?;
             }
             Self::Bytes => {
-                write!(f, "Bytes")?;
+                write!(f, "bytes")?;
             }
-            Self::Float64 => {
-                write!(f, "Float64")?;
+            Self::F64 => {
+                write!(f, "f64")?;
             }
-            Self::Unsigned64 => {
-                write!(f, "Unsigned64")?;
+            Self::U64 => {
+                write!(f, "u64")?;
             }
             Self::Custom(import, name) => {
                 if let Some(import) = import {
@@ -430,7 +430,7 @@ mod tests {
                 unstable: false,
                 r#type: Type {
                     source_range: SourceRange { start: 0, end: 0 },
-                    variant: TypeVariant::Boolean,
+                    variant: TypeVariant::Bool,
                 },
                 index: 0,
             },
@@ -440,7 +440,7 @@ mod tests {
                 unstable: false,
                 r#type: Type {
                     source_range: SourceRange { start: 0, end: 0 },
-                    variant: TypeVariant::Unsigned64,
+                    variant: TypeVariant::U64,
                 },
                 index: 1,
             },
@@ -453,7 +453,7 @@ mod tests {
                 unstable: false,
                 r#type: Type {
                     source_range: SourceRange { start: 0, end: 0 },
-                    variant: TypeVariant::Boolean,
+                    variant: TypeVariant::Bool,
                 },
                 index: 0,
             },
@@ -463,7 +463,7 @@ mod tests {
                 unstable: false,
                 r#type: Type {
                     source_range: SourceRange { start: 0, end: 0 },
-                    variant: TypeVariant::Float64,
+                    variant: TypeVariant::F64,
                 },
                 index: 1,
             },
@@ -472,7 +472,7 @@ mod tests {
         let mut declarations = BTreeMap::new();
 
         declarations.insert(
-            "Foo".into(),
+            "foo".into(),
             Declaration {
                 source_range: SourceRange { start: 0, end: 0 },
                 variant: DeclarationVariant::Struct(foo_fields),
@@ -480,7 +480,7 @@ mod tests {
         );
 
         declarations.insert(
-            "Bar".into(),
+            "bar".into(),
             Declaration {
                 source_range: SourceRange { start: 0, end: 0 },
                 variant: DeclarationVariant::Choice(bar_fields),
@@ -493,14 +493,14 @@ mod tests {
         };
 
         let expected = "\
-            choice Bar {\n\
-            \x20 x: Boolean = 0\n\
-            \x20 y: Float64 = 1\n\
+            choice bar {\n\
+            \x20 x: bool = 0\n\
+            \x20 y: f64 = 1\n\
             }\n\
             \n\
-            struct Foo {\n\
-            \x20 x: Boolean = 0\n\
-            \x20 y: Unsigned64 = 1\n\
+            struct foo {\n\
+            \x20 x: bool = 0\n\
+            \x20 y: u64 = 1\n\
             }\n\
         ";
 
@@ -537,7 +537,7 @@ mod tests {
                 unstable: false,
                 r#type: Type {
                     source_range: SourceRange { start: 0, end: 0 },
-                    variant: TypeVariant::Boolean,
+                    variant: TypeVariant::Bool,
                 },
                 index: 0,
             },
@@ -547,7 +547,7 @@ mod tests {
                 unstable: false,
                 r#type: Type {
                     source_range: SourceRange { start: 0, end: 0 },
-                    variant: TypeVariant::Unsigned64,
+                    variant: TypeVariant::U64,
                 },
                 index: 1,
             },
@@ -560,7 +560,7 @@ mod tests {
                 unstable: false,
                 r#type: Type {
                     source_range: SourceRange { start: 0, end: 0 },
-                    variant: TypeVariant::Boolean,
+                    variant: TypeVariant::Bool,
                 },
                 index: 0,
             },
@@ -570,7 +570,7 @@ mod tests {
                 unstable: false,
                 r#type: Type {
                     source_range: SourceRange { start: 0, end: 0 },
-                    variant: TypeVariant::Float64,
+                    variant: TypeVariant::F64,
                 },
                 index: 1,
             },
@@ -579,7 +579,7 @@ mod tests {
         let mut declarations = BTreeMap::new();
 
         declarations.insert(
-            "Foo".into(),
+            "foo".into(),
             Declaration {
                 source_range: SourceRange { start: 0, end: 0 },
                 variant: DeclarationVariant::Struct(foo_fields),
@@ -587,7 +587,7 @@ mod tests {
         );
 
         declarations.insert(
-            "Bar".into(),
+            "bar".into(),
             Declaration {
                 source_range: SourceRange { start: 0, end: 0 },
                 variant: DeclarationVariant::Choice(bar_fields),
@@ -603,14 +603,14 @@ mod tests {
             import 'bar.t' as bar\n\
             import 'foo.t' as foo\n\
             \n\
-            choice Bar {\n\
-            \x20 x: Boolean = 0\n\
-            \x20 y: Float64 = 1\n\
+            choice bar {\n\
+            \x20 x: bool = 0\n\
+            \x20 y: f64 = 1\n\
             }\n\
             \n\
-            struct Foo {\n\
-            \x20 x: Boolean = 0\n\
-            \x20 y: Unsigned64 = 1\n\
+            struct foo {\n\
+            \x20 x: bool = 0\n\
+            \x20 y: u64 = 1\n\
             }\n\
         ";
 
@@ -621,10 +621,10 @@ mod tests {
     fn type_display_boolean() {
         let r#type = Type {
             source_range: SourceRange { start: 0, end: 0 },
-            variant: TypeVariant::Boolean,
+            variant: TypeVariant::Bool,
         };
 
-        let expected = "Boolean";
+        let expected = "bool";
 
         assert_eq!(r#type.to_string(), expected);
     }
@@ -636,7 +636,7 @@ mod tests {
             variant: TypeVariant::Bytes,
         };
 
-        let expected = "Bytes";
+        let expected = "bytes";
 
         assert_eq!(r#type.to_string(), expected);
     }
@@ -645,10 +645,10 @@ mod tests {
     fn type_display_float64() {
         let r#type = Type {
             source_range: SourceRange { start: 0, end: 0 },
-            variant: TypeVariant::Float64,
+            variant: TypeVariant::F64,
         };
 
-        let expected = "Float64";
+        let expected = "f64";
 
         assert_eq!(r#type.to_string(), expected);
     }
@@ -657,10 +657,10 @@ mod tests {
     fn type_display_unsigned64() {
         let r#type = Type {
             source_range: SourceRange { start: 0, end: 0 },
-            variant: TypeVariant::Unsigned64,
+            variant: TypeVariant::U64,
         };
 
-        let expected = "Unsigned64";
+        let expected = "u64";
 
         assert_eq!(r#type.to_string(), expected);
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -6,13 +6,13 @@ use std::{
 
 // Keywords
 pub const AS_KEYWORD: &str = "as";
-pub const BOOLEAN_KEYWORD: &str = "Boolean";
-pub const BYTES_KEYWORD: &str = "Bytes";
+pub const BOOLEAN_KEYWORD: &str = "bool";
+pub const BYTES_KEYWORD: &str = "bytes";
 pub const CHOICE_KEYWORD: &str = "choice";
-pub const FLOAT64_KEYWORD: &str = "Float64";
+pub const FLOAT64_KEYWORD: &str = "f64";
 pub const IMPORT_KEYWORD: &str = "import";
 pub const STRUCT_KEYWORD: &str = "struct";
-pub const UNSIGNED64_KEYWORD: &str = "Unsigned64";
+pub const UNSIGNED64_KEYWORD: &str = "u64";
 pub const UNSTABLE_KEYWORD: &str = "unstable";
 
 // The first step of compilation is to split the source into a stream of tokens. This struct
@@ -27,13 +27,13 @@ pub struct Token {
 #[derive(Clone, Debug)]
 pub enum Variant {
     As,
-    Boolean,
+    Bool,
     Bytes,
     Choice,
     Colon,
     Dot,
     Equals,
-    Float64,
+    F64,
     Identifier(Identifier),
     Import,
     Integer(usize),
@@ -41,7 +41,7 @@ pub enum Variant {
     Path(PathBuf),
     RightCurly,
     Struct,
-    Unsigned64,
+    U64,
     Unstable,
 }
 
@@ -55,13 +55,13 @@ impl Display for Variant {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
             Self::As => write!(f, "{}", AS_KEYWORD),
-            Self::Boolean => write!(f, "{}", BOOLEAN_KEYWORD),
+            Self::Bool => write!(f, "{}", BOOLEAN_KEYWORD),
             Self::Bytes => write!(f, "{}", BYTES_KEYWORD),
             Self::Choice => write!(f, "{}", CHOICE_KEYWORD),
             Self::Colon => write!(f, ":"),
             Self::Dot => write!(f, "."),
             Self::Equals => write!(f, "="),
-            Self::Float64 => write!(f, "{}", FLOAT64_KEYWORD),
+            Self::F64 => write!(f, "{}", FLOAT64_KEYWORD),
             Self::Identifier(name) => write!(f, "{}", name.original()),
             Self::Import => write!(f, "{}", IMPORT_KEYWORD),
             Self::Integer(integer) => write!(f, "{}", integer),
@@ -69,7 +69,7 @@ impl Display for Variant {
             Self::Path(path) => write!(f, "'{}'", path.display()),
             Self::RightCurly => write!(f, "}}"),
             Self::Struct => write!(f, "{}", STRUCT_KEYWORD),
-            Self::Unsigned64 => write!(f, "{}", UNSIGNED64_KEYWORD),
+            Self::U64 => write!(f, "{}", UNSIGNED64_KEYWORD),
             Self::Unstable => write!(f, "{}", UNSTABLE_KEYWORD),
         }
     }
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn variant_bool_display() {
-        assert_eq!(format!("{}", Variant::Boolean), BOOLEAN_KEYWORD);
+        assert_eq!(format!("{}", Variant::Bool), BOOLEAN_KEYWORD);
     }
 
     #[test]
@@ -137,12 +137,12 @@ mod tests {
 
     #[test]
     fn variant_float64_display() {
-        assert_eq!(format!("{}", Variant::Float64), FLOAT64_KEYWORD);
+        assert_eq!(format!("{}", Variant::F64), FLOAT64_KEYWORD);
     }
 
     #[test]
     fn variant_identifier_display() {
-        assert_eq!(format!("{}", Variant::Identifier("Foo".into())), "Foo");
+        assert_eq!(format!("{}", Variant::Identifier("foo".into())), "foo");
     }
 
     #[test]
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn variant_unsigned64_display() {
-        assert_eq!(format!("{}", Variant::Unsigned64), UNSIGNED64_KEYWORD);
+        assert_eq!(format!("{}", Variant::U64), UNSIGNED64_KEYWORD);
     }
 
     #[test]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -100,7 +100,7 @@ pub fn tokenize(schema_path: &Path, schema_contents: &str) -> Result<Vec<Token>,
                 } else if &schema_contents[i..end] == BOOLEAN_KEYWORD {
                     tokens.push(Token {
                         source_range: SourceRange { start: i, end },
-                        variant: Variant::Boolean,
+                        variant: Variant::Bool,
                     });
                 } else if &schema_contents[i..end] == BYTES_KEYWORD {
                     tokens.push(Token {
@@ -115,7 +115,7 @@ pub fn tokenize(schema_path: &Path, schema_contents: &str) -> Result<Vec<Token>,
                 } else if &schema_contents[i..end] == FLOAT64_KEYWORD {
                     tokens.push(Token {
                         source_range: SourceRange { start: i, end },
-                        variant: Variant::Float64,
+                        variant: Variant::F64,
                     });
                 } else if &schema_contents[i..end] == IMPORT_KEYWORD {
                     tokens.push(Token {
@@ -130,7 +130,7 @@ pub fn tokenize(schema_path: &Path, schema_contents: &str) -> Result<Vec<Token>,
                 } else if &schema_contents[i..end] == UNSIGNED64_KEYWORD {
                     tokens.push(Token {
                         source_range: SourceRange { start: i, end },
-                        variant: Variant::Unsigned64,
+                        variant: Variant::U64,
                     });
                 } else if &schema_contents[i..end] == UNSTABLE_KEYWORD {
                     tokens.push(Token {
@@ -302,15 +302,15 @@ mod tests {
 
             # This is a struct.
             struct plugh {
-              qux: bar.Foo = 0
-              corge: unstable Boolean = 1
+              qux: bar.foo = 0
+              corge: unstable bool = 1
             }
 
             # This is a choice.
             choice zyzzy {
-              grault: bar.Bar = 0
-              garply: unstable Float64 = 1
-              wobble: Unsigned64 = 2
+              grault: bar.bar = 0
+              garply: unstable f64 = 1
+              wobble: u64 = 2
             }
         ";
 
@@ -378,7 +378,7 @@ mod tests {
                         start: 118,
                         end: 121,
                     },
-                    variant: Variant::Identifier("Foo".into()),
+                    variant: Variant::Identifier("foo".into()),
                 },
                 Token {
                     source_range: SourceRange {
@@ -418,182 +418,182 @@ mod tests {
                 Token {
                     source_range: SourceRange {
                         start: 156,
-                        end: 163,
+                        end: 160,
                     },
-                    variant: Variant::Boolean,
+                    variant: Variant::Bool,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 164,
-                        end: 165,
+                        start: 161,
+                        end: 162,
                     },
                     variant: Variant::Equals,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 166,
-                        end: 167,
+                        start: 163,
+                        end: 164,
                     },
                     variant: Variant::Integer(1),
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 180,
-                        end: 181,
+                        start: 177,
+                        end: 178,
                     },
                     variant: Variant::RightCurly,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 227,
-                        end: 233,
+                        start: 224,
+                        end: 230,
                     },
                     variant: Variant::Choice,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 234,
-                        end: 239,
+                        start: 231,
+                        end: 236,
                     },
                     variant: Variant::Identifier("zyzzy".into()),
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 240,
-                        end: 241,
+                        start: 237,
+                        end: 238,
                     },
                     variant: Variant::LeftCurly,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 256,
-                        end: 262,
+                        start: 253,
+                        end: 259,
                     },
                     variant: Variant::Identifier("grault".into()),
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 262,
-                        end: 263,
+                        start: 259,
+                        end: 260,
                     },
                     variant: Variant::Colon,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 264,
-                        end: 267,
+                        start: 261,
+                        end: 264,
                     },
                     variant: Variant::Identifier("bar".into()),
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 267,
-                        end: 268,
+                        start: 264,
+                        end: 265,
                     },
                     variant: Variant::Dot,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 268,
-                        end: 271,
+                        start: 265,
+                        end: 268,
                     },
-                    variant: Variant::Identifier("Bar".into()),
+                    variant: Variant::Identifier("bar".into()),
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 272,
-                        end: 273,
+                        start: 269,
+                        end: 270,
                     },
                     variant: Variant::Equals,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 274,
-                        end: 275,
+                        start: 271,
+                        end: 272,
                     },
                     variant: Variant::Integer(0),
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 290,
-                        end: 296,
+                        start: 287,
+                        end: 293,
                     },
                     variant: Variant::Identifier("garply".into()),
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 296,
-                        end: 297,
+                        start: 293,
+                        end: 294,
                     },
                     variant: Variant::Colon,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 298,
-                        end: 306,
+                        start: 295,
+                        end: 303,
                     },
                     variant: Variant::Unstable,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 307,
-                        end: 314,
+                        start: 304,
+                        end: 307,
                     },
-                    variant: Variant::Float64,
+                    variant: Variant::F64,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 315,
-                        end: 316,
+                        start: 308,
+                        end: 309,
                     },
                     variant: Variant::Equals,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 317,
-                        end: 318,
+                        start: 310,
+                        end: 311,
                     },
                     variant: Variant::Integer(1),
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 333,
-                        end: 339,
+                        start: 326,
+                        end: 332,
                     },
                     variant: Variant::Identifier("wobble".into()),
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 339,
-                        end: 340,
+                        start: 332,
+                        end: 333,
                     },
                     variant: Variant::Colon,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 341,
-                        end: 351,
+                        start: 334,
+                        end: 337,
                     },
-                    variant: Variant::Unsigned64,
+                    variant: Variant::U64,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 352,
-                        end: 353,
+                        start: 338,
+                        end: 339,
                     },
                     variant: Variant::Equals,
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 354,
-                        end: 355,
+                        start: 340,
+                        end: 341,
                     },
                     variant: Variant::Integer(2),
                 },
                 Token {
                     source_range: SourceRange {
-                        start: 368,
-                        end: 369,
+                        start: 354,
+                        end: 355,
                     },
                     variant: Variant::RightCurly,
                 },
@@ -642,7 +642,7 @@ mod tests {
                     start: 0,
                     end: BOOLEAN_KEYWORD.len(),
                 },
-                variant: Variant::Boolean,
+                variant: Variant::Bool,
             }],
         );
     }
@@ -717,7 +717,7 @@ mod tests {
                     start: 0,
                     end: FLOAT64_KEYWORD.len(),
                 },
-                variant: Variant::Float64,
+                variant: Variant::F64,
             }],
         );
     }
@@ -856,7 +856,7 @@ mod tests {
                     start: 0,
                     end: UNSIGNED64_KEYWORD.len(),
                 },
-                variant: Variant::Unsigned64,
+                variant: Variant::U64,
             }],
         );
     }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -89,10 +89,10 @@ pub fn validate(
 
                         // Validate the type.
                         match &field.r#type.variant {
-                            schema::TypeVariant::Boolean
+                            schema::TypeVariant::Bool
                             | schema::TypeVariant::Bytes
-                            | schema::TypeVariant::Float64
-                            | schema::TypeVariant::Unsigned64 => {}
+                            | schema::TypeVariant::F64
+                            | schema::TypeVariant::U64 => {}
                             schema::TypeVariant::Custom(import, name) => {
                                 // Determine which file the type is from.
                                 let type_namespace = if let Some(import) = import {
@@ -237,10 +237,10 @@ fn check_type_for_cycles(
         schema::DeclarationVariant::Struct(fields) | schema::DeclarationVariant::Choice(fields) => {
             for field in fields {
                 match &field.r#type.variant {
-                    schema::TypeVariant::Boolean
+                    schema::TypeVariant::Bool
                     | schema::TypeVariant::Bytes
-                    | schema::TypeVariant::Float64
-                    | schema::TypeVariant::Unsigned64 => {}
+                    | schema::TypeVariant::F64
+                    | schema::TypeVariant::U64 => {}
                     schema::TypeVariant::Custom(import, type_name) => {
                         let type_namespace = import.as_ref().map_or_else(
                             || namespace.clone(),
@@ -314,9 +314,9 @@ mod tests {
         let foo_contents = "
             import 'bar.t' as bar
 
-            struct Foo {
-              x: bar.Bar = 0
-              y: bar.Bar = 1
+            struct foo {
+              x: bar.bar = 0
+              y: bar.bar = 1
             }
         "
         .to_owned();
@@ -326,9 +326,9 @@ mod tests {
         };
         let bar_path = Path::new("bar.t").to_owned();
         let bar_contents = "
-            choice Bar {
-              x: Boolean = 0
-              y: Float64 = 1
+            choice bar {
+              x: bool = 0
+              y: f64 = 1
             }
         "
         .to_owned();
@@ -354,9 +354,9 @@ mod tests {
         };
         let path = Path::new("foo.t").to_owned();
         let contents = "
-            struct Bar {
-              x: Boolean = 0
-              x: Float64 = 1
+            struct bar {
+              x: bool = 0
+              x: f64 = 1
             }
         "
         .to_owned();
@@ -379,9 +379,9 @@ mod tests {
         };
         let path = Path::new("foo.t").to_owned();
         let contents = "
-            struct Bar {
-              x: Boolean = 0
-              y: Float64 = 0
+            struct bar {
+              x: bool = 0
+              y: f64 = 0
             }
         "
         .to_owned();
@@ -404,9 +404,9 @@ mod tests {
         };
         let path = Path::new("foo.t").to_owned();
         let contents = "
-            choice Bar {
-              x: Boolean = 0
-              x: Float64 = 1
+            choice bar {
+              x: bool = 0
+              x: f64 = 1
             }
         "
         .to_owned();
@@ -429,9 +429,9 @@ mod tests {
         };
         let path = Path::new("foo.t").to_owned();
         let contents = "
-            choice Bar {
-              x: Boolean = 0
-              y: Float64 = 0
+            choice bar {
+              x: bool = 0
+              y: f64 = 0
             }
         "
         .to_owned();
@@ -454,8 +454,8 @@ mod tests {
         };
         let path = Path::new("foo.t").to_owned();
         let contents = "
-            struct Foo {
-              x: bar.Bar = 0
+            struct foo {
+              x: bar.bar = 0
             }
         "
         .to_owned();
@@ -478,8 +478,8 @@ mod tests {
         };
         let path = Path::new("foo.t").to_owned();
         let contents = "
-            struct Foo {
-              x: Bar = 0
+            struct foo {
+              x: bar = 0
             }
         "
         .to_owned();
@@ -491,7 +491,7 @@ mod tests {
 
         assert_fails!(
             validate(&schemas),
-            "There is no type named `Bar` in this file.",
+            "There is no type named `bar` in this file.",
         );
     }
 
@@ -504,8 +504,8 @@ mod tests {
         let foo_contents = "
             import 'bar.t' as bar
 
-            struct Foo {
-              x: bar.Bar = 0
+            struct foo {
+              x: bar.bar = 0
             }
         "
         .to_owned();
@@ -515,7 +515,7 @@ mod tests {
         };
         let bar_path = Path::new("bar.t").to_owned();
         let bar_contents = "
-            struct Qux {
+            struct qux {
             }
         "
         .to_owned();
@@ -533,7 +533,7 @@ mod tests {
 
         assert_fails!(
             validate(&schemas),
-            "There is no type named `Bar` in import `bar`.",
+            "There is no type named `bar` in import `bar`.",
         );
     }
 
@@ -546,8 +546,8 @@ mod tests {
         let foo_contents = "
             import 'bar.t' as bar
 
-            struct Foo {
-              x: bar.Bar = 0
+            struct foo {
+              x: bar.bar = 0
             }
         "
         .to_owned();
@@ -559,8 +559,8 @@ mod tests {
         let bar_contents = "
             import 'foo.t' as foo
 
-            choice Bar {
-              x: foo.Foo = 0
+            choice bar {
+              x: foo.foo = 0
             }
         "
         .to_owned();
@@ -579,7 +579,7 @@ mod tests {
 
         assert_fails!(
             validate(&schemas),
-            "Cycle detected: `bar.Bar` \u{2192} `foo.Foo` \u{2192} `bar.Bar`.",
+            "Cycle detected: `bar.bar` \u{2192} `foo.foo` \u{2192} `bar.bar`.",
         );
     }
 }


### PR DESCRIPTION
Switch the convention to use lowercase type names in schemas.

It looks nicer with modules (e.g., `foo.foo`), and typing `Boolean` feels a little too ceremonial.

**Status:** Ready

**Fixes:** N/A
