### PR TITLE
Use UpperCamelCase for the names of types

### DIFF
--- a/example/types.t
+++ b/example/types.t
@@ -1,4 +1,4 @@
-struct send_email_request {
+struct SendEmailRequest {
     to: string = 0
     subject: string = 1
     body: string = 2

--- a/integration_tests/types/circular_dependency/dependency/main.t
+++ b/integration_tests/types/circular_dependency/dependency/main.t
@@ -1,5 +1,5 @@
 import '../main.t'
 
-struct struct_from_below {
-    x: main.struct_from_above = 0
+struct StructFromBelow {
+    x: main.StructFromAbove = 0
 }

--- a/integration_tests/types/circular_dependency/main.t
+++ b/integration_tests/types/circular_dependency/main.t
@@ -1,4 +1,4 @@
 import 'dependency/main.t'
 
-struct struct_from_above {
+struct StructFromAbove {
 }

--- a/integration_tests/types/comprehensive/bar.t
+++ b/integration_tests/types/comprehensive/bar.t
@@ -1,4 +1,4 @@
-choice bar {
+choice Bar {
     p_required: [unit] = 0
     q_required: [f64] = 1
     r_required: [s64] = 2

--- a/integration_tests/types/comprehensive/foo.t
+++ b/integration_tests/types/comprehensive/foo.t
@@ -1,4 +1,4 @@
-struct foo {
+struct Foo {
     p_required: [unit] = 0
     q_required: [f64] = 1
     r_required: [s64] = 2

--- a/integration_tests/types/comprehensive/main.t
+++ b/integration_tests/types/comprehensive/main.t
@@ -1,18 +1,18 @@
 import 'bar.t'
 import 'foo.t'
 
-struct empty_struct {
+struct EmptyStruct {
 }
 
-choice empty_choice {
+choice EmptyChoice {
 }
 
-struct foo_and_bar {
-    x: foo.foo = 0
-    y: bar.bar = 1
+struct FooAndBar {
+    x: foo.Foo = 0
+    y: bar.Bar = 1
 }
 
-choice foo_or_bar {
-    x: foo.foo = 0
-    y: bar.bar = 1
+choice FooOrBar {
+    x: foo.Foo = 0
+    y: bar.Bar = 1
 }

--- a/integration_tests/types/schema_evolution/after.t
+++ b/integration_tests/types/schema_evolution/after.t
@@ -1,4 +1,4 @@
-struct example_struct {
+struct ExampleStruct {
     required_to_required: string = 0
     asymmetric required_to_asymmetric: string = 1
     optional required_to_optional: string = 2
@@ -25,7 +25,7 @@ struct example_struct {
     # nonexistent_to_nonexistent: string = 19
 }
 
-choice example_choice {
+choice ExampleChoice {
     required_to_required: string = 0
     asymmetric required_to_asymmetric: string = 1
     # optional required_to_optional_handled: string = 2 # This case would be an error.

--- a/integration_tests/types/schema_evolution/before.t
+++ b/integration_tests/types/schema_evolution/before.t
@@ -1,4 +1,4 @@
-struct example_struct {
+struct ExampleStruct {
     required_to_required: string = 0
     required_to_asymmetric: string = 1
     required_to_optional: string = 2
@@ -25,7 +25,7 @@ struct example_struct {
     # nonexistent_to_nonexistent: string = 19
 }
 
-choice example_choice {
+choice ExampleChoice {
     required_to_required: string = 0
     required_to_asymmetric: string = 1
     # required_to_optional_handled: string = 2 # This case would be an error.


### PR DESCRIPTION
Use `UpperCamelCase` for the names of types. I think most people prefer this style.

One aspect of this convention that I don't like is that it's ambiguous how to split words for names that have digits, like `IpV4Address`, since numbers don't have a letter case. We treat digits like lowercase letters (i.e., they do not split words). So `IpV4Address` is considered three words (`ip`, `v4`, `address`), not four (`ip`, `v`, `4`, `address`).

Separately, another aspect of the current style that might cause trouble is that we're using `snake_case` for fields in both `structs` and `choice`s, but most programmers are accustomed to using `UpperCamelCase` or `CONSTANT_CASE` for `choice` variants—especially the latter for simple enumerated types. However, due to the duality of `struct`s and `choice`s in Typical, I prefer to use a consistent naming convention for their fields. So `snake_case` it is.

cc @juliahw

**Status:** Ready

**Fixes:** N/A
