### PR TITLE
Improve the `format` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2021-12-14
+## [0.2.1] - 2021-12-16
+
+### Changed
+- Slightly improved the `format` subcommand behavior such that it is now always possible to have a top-level comment. Previously, in some situations, a comment intended to be a top-level comment would be interpreted as a comment on the first declaration.
+
+## [0.2.0] - 2021-12-16
 
 ### Added
 - Added the `format` subcommand.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "typical"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typical"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "Algebraic data types for data interchange."

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -248,7 +248,14 @@ fn parse_schema(
         if let token::Variant::Comment(paragraphs) = &tokens[*position].variant {
             if *position + 1 < tokens.len() {
                 match tokens[*position + 1].variant {
-                    token::Variant::Struct | token::Variant::Choice => {}
+                    token::Variant::Struct | token::Variant::Choice => {
+                        if tokens[*position].source_range.end + 1
+                            < tokens[*position + 1].source_range.start
+                        {
+                            comment = paragraphs.clone();
+                            *position += 1;
+                        }
+                    }
                     _ => {
                         comment = paragraphs.clone();
                         *position += 1;


### PR DESCRIPTION
Improve the `format` subcommand. Previously, in some situations, a comment intended to be a top-level comment would be interpreted as a comment on the first declaration.

**Status:** Ready

**Fixes:** N/A
