### PR TITLE
Update the instructions for installing from and updating Homebrew

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -33,3 +33,4 @@ Releasing a new version is a three-step process:
 1. Run `(cd integration_tests/typescript-web && npm ci && npm run dev)` to run the browser-based integration tests. This is the only test suite that isn't automated.
 2. Bump the version in `Cargo.toml`, run `cargo build` to update `Cargo.lock`, and update `CHANGELOG.md` with information about the new version. Ship those changes as a single commit.
 3. Once the GitHub workflow has finished on the `main` branch, update the version in `install.sh` to point to the new release.
+4. Create a pull request in the `Homebrew/homebrew-core` repository on GitHub to bump the version in [this file](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/typical.rb).

--- a/README.md
+++ b/README.md
@@ -719,6 +719,16 @@ If you're running Windows (AArch64 or x86-64), download the latest binary from t
 
 To update to an existing installation, simply replace the existing binary.
 
+### Installation with Homebrew
+
+If you have [Homebrew](https://brew.sh/), you can install Typical as follows:
+
+```sh
+brew install typical
+```
+
+You can update an existing installation with `brew upgrade typical`.
+
 ### Installation with Cargo
 
 If you have [Cargo](https://doc.rust-lang.org/cargo/), you can install Typical as follows:


### PR DESCRIPTION
Update the instructions for installing from and updating Homebrew.

**Status:** Ready once https://github.com/Homebrew/homebrew-core/pull/134063 is merged.

**Fixes:** N/A