### PR TITLE
Update the way lints are configured to use Rust's new `manifest-lint` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ homepage = "https://github.com/stepchowfun/typical"
 repository = "https://github.com/stepchowfun/typical"
 readme = "README.md"
 
+[lints]
+clippy.all = "deny"
+clippy.pedantic = "deny"
+rust.warnings = "deny"
+
 [dependencies]
 colored = "1"
 pad = "0.1"

--- a/benchmarks/rust/Cargo.toml
+++ b/benchmarks/rust/Cargo.toml
@@ -4,4 +4,9 @@ version = "0.1.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 
+[lints]
+clippy.all = "deny"
+clippy.pedantic = "deny"
+rust.warnings = "deny"
+
 [dependencies]

--- a/benchmarks/rust/build.rs
+++ b/benchmarks/rust/build.rs
@@ -23,9 +23,9 @@ fn main() {
 
     assert!(output.status.success());
 
-    for line in output.stdout.lines().map(|line| line.unwrap()) {
+    for line in output.stdout.lines().map(Result::unwrap) {
         if !line.is_empty() {
-            println!("cargo:rerun-if-changed={}", line);
+            println!("cargo:rerun-if-changed={line}");
         }
     }
 }

--- a/benchmarks/rust/src/main.rs
+++ b/benchmarks/rust/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::all, clippy::pedantic, warnings)]
-
 mod types;
 
 use {

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -4,4 +4,9 @@ version = "0.1.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 
+[lints]
+clippy.all = "deny"
+clippy.pedantic = "deny"
+rust.warnings = "deny"
+
 [dependencies]

--- a/examples/rust/build.rs
+++ b/examples/rust/build.rs
@@ -23,9 +23,9 @@ fn main() {
 
     assert!(output.status.success());
 
-    for line in output.stdout.lines().map(|line| line.unwrap()) {
+    for line in output.stdout.lines().map(Result::unwrap) {
         if !line.is_empty() {
-            println!("cargo:rerun-if-changed={}", line);
+            println!("cargo:rerun-if-changed={line}");
         }
     }
 }

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::all, clippy::pedantic, warnings)]
-
 mod types;
 
 use {

--- a/integration_tests/rust/Cargo.toml
+++ b/integration_tests/rust/Cargo.toml
@@ -4,4 +4,9 @@ version = "0.1.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 
+[lints]
+clippy.all = "deny"
+clippy.pedantic = "deny"
+rust.warnings = "deny"
+
 [dependencies]

--- a/integration_tests/rust/build.rs
+++ b/integration_tests/rust/build.rs
@@ -23,9 +23,9 @@ fn main() {
 
     assert!(output.status.success());
 
-    for line in output.stdout.lines().map(|line| line.unwrap()) {
+    for line in output.stdout.lines().map(Result::unwrap) {
         if !line.is_empty() {
-            println!("cargo:rerun-if-changed={}", line);
+            println!("cargo:rerun-if-changed={line}");
         }
     }
 }

--- a/integration_tests/rust/src/main.rs
+++ b/integration_tests/rust/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::all, clippy::pedantic, warnings)]
-
 mod assertions;
 mod circular_dependency;
 mod comprehensive;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::all, clippy::pedantic, warnings)]
-
 mod assertions;
 mod count;
 mod error;


### PR DESCRIPTION
Update the way lints are configured to use Rust's new `manifest-lint` feature.

**Status:** Ready

**Fixes:** N/A