### PR TITLE
Update the CI workflow to not run twice on every internal pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Continuous integration
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 defaults:
   run:
     shell: bash
@@ -18,6 +22,7 @@ jobs:
       with:
         tasks: build test_units test_rust_integration test_typescript_integration lint release run
         docker_repo: stephanmisc/toast
+        read_remote_cache: ${{ github.event_name == 'push' }}
         write_remote_cache: ${{ github.event_name == 'push' }}
     - run: |
         # Make Bash not silently ignore errors.


### PR DESCRIPTION
Update the CI workflow to not run twice on every internal pull request.

**Status:** Ready

**Fixes:** N/A