### PR TITLE
Change the case convention of a field for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ Each code generator produces a single self-contained source file regardless of t
 
   ```perl
   struct Square {
-      sideLength: F64 = 0
+      side_length: F64 = 0
   }
 
   struct Rectangle {


### PR DESCRIPTION
Change the case convention of a field for consistency.

**Status:** Ready

**Fixes:** N/A