### PR TITLE
Fix a bug in the toastfile

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -580,7 +580,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn validate_duplicate_choice_field_names() {
         let namespace = Namespace {

--- a/toast.yml
+++ b/toast.yml
@@ -250,7 +250,7 @@ tasks:
       typical format --check integration_tests/types/types.t
 
       # Lint the Rust projects.
-      for PROJECT_PATH in benchmarks/rust examples/rust integration_tests/rust; do
+      for PROJECT_PATH in . benchmarks/rust examples/rust integration_tests/rust; do
         (
           cd "$PROJECT_PATH" &&
 
@@ -334,7 +334,7 @@ tasks:
       typical format integration_tests/types/types.t
 
       # Format the Rust projects.
-      for PROJECT_PATH in benchmarks/rust examples/rust integration_tests/rust; do
+      for PROJECT_PATH in . benchmarks/rust examples/rust integration_tests/rust; do
         (
           cd "$PROJECT_PATH" &&
 


### PR DESCRIPTION
The linters weren't running on the root project (Typical itself)! Fortunately, this bug was introduced very recently, so there was only one issue that needed to be fixed (a formatting issue).

**Status:** Ready

**Fixes:** N/A