### PR TITLE
Update the Rust deserialization benchmark to not include message deallocation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,14 +648,14 @@ One benchmark serializes and deserializes a large message containing several hun
 |                                     | Rust         | TypeScript   |
 | ----------------------------------- | ------------ | ------------ |
 | **Per-thread serialization rate**   | 11.663 GiB/s | 11.092 GiB/s |
-| **Per-thread deserialization rate** | 6.030 GiB/s  | 7.915 GiB/s  |
+| **Per-thread deserialization rate** | 7.568 GiB/s  | 7.915 GiB/s  |
 
 Another benchmark repeatedly serializes and deserializes a pathological message containing many small and deeply nested values:
 
 |                                     | Rust          | TypeScript   |
 | ----------------------------------- | ------------- | ------------ |
 | **Per-thread serialization rate**   | 688.198 MiB/s | 48.992 MiB/s |
-| **Per-thread deserialization rate** | 290.701 MiB/s | 2.341 MiB/s  |
+| **Per-thread deserialization rate** | 303.313 MiB/s | 2.341 MiB/s  |
 
 These benchmarks represent two extremes. Real-world performance will be somewhere in the middle.
 

--- a/benchmarks/rust/src/main.rs
+++ b/benchmarks/rust/src/main.rs
@@ -1,7 +1,7 @@
 mod types;
 
 use {
-    std::{f64::consts::PI, io, time::Instant},
+    std::{f64::consts::PI, io, mem::forget, time::Instant},
     types::{
         types::{ChoiceOut, MessageIn, MessageOut, StructIn, StructOut},
         Deserialize, Serialize,
@@ -94,7 +94,11 @@ fn benchmark<T: Serialize, U: Deserialize>(message: &T, iterations: usize) -> io
 
     for i in 0..iterations {
         let offset = message_size * i;
-        U::deserialize(&buffer[offset..offset + message_size])?;
+        let message = U::deserialize(&buffer[offset..offset + message_size])?;
+
+        // Don't deallocate the memory in this loop, since that isn't what the benchmark is
+        // intended to measure.
+        forget(message);
     }
 
     let deserialization_duration = deserialization_instant.elapsed();


### PR DESCRIPTION
Update the Rust deserialization benchmark to not include message deallocation time.

**Status:** Ready

**Fixes:** N/A