### PR TITLE
fix: eliminate needless lifetimes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,7 +34,7 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn source<'a>(&'a self) -> Option<&'a (dyn error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         self.reason.as_deref()
     }
 }


### PR DESCRIPTION
seeing some regression build issue against rust 1.83.0 as 

```
  error: elided lifetime has a name
    --> src/error.rs:37:39
     |
  37 |     fn source<'a>(&'a self) -> Option<&(dyn error::Error + 'static)> {
     |               --                      ^ this elided lifetime gets resolved as `'a`
     |               |
     |               lifetime `'a` declared here
     |
     = note: `-D elided-named-lifetimes` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(elided_named_lifetimes)]`
```

**Status:** Ready

relates to https://github.com/Homebrew/homebrew-core/pull/199379
