### PR TITLE
Add publish release Docker login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,10 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v4
+    - uses: docker/login-action@v3
+      with:
+        username: stephanmisc
+        password: ${{ secrets.DOCKER_PASSWORD }}
     - uses: actions/download-artifact@v4
       with:
         path: artifacts/


### PR DESCRIPTION
Adds Docker login to the publish-release job before artifacts are downloaded, so the Toast publish step can write remote cache entries.

**Status:** Ready

**Fixes:** N/A