### PR TITLE
Fix TypeScript Buffer boundaries

### DIFF
--- a/examples/typescript/src/main.ts
+++ b/examples/typescript/src/main.ts
@@ -17,21 +17,25 @@ function writeToFiles(): void {
   };
 
   const requestArrayBuffer = SendEmailRequest.serialize(requestMessage);
-  writeFileSync(requestFilePath, Buffer.from(requestArrayBuffer));
+  writeFileSync(requestFilePath, new Uint8Array(requestArrayBuffer));
 
   const responseArrayBuffer = SendEmailResponse.serialize(responseMessage);
-  writeFileSync(responseFilePath, Buffer.from(responseArrayBuffer));
+  writeFileSync(responseFilePath, new Uint8Array(responseArrayBuffer));
 }
 
 function readFromFiles(): void {
   const requestFileContents = readFileSync(requestFilePath);
-  const requestMessage = SendEmailRequest.deserialize(requestFileContents);
+  const requestMessage = SendEmailRequest.deserialize(
+    new Uint8Array(requestFileContents),
+  );
   if (requestMessage instanceof Error) {
     throw requestMessage;
   }
 
   const responseFileContents = readFileSync(responseFilePath);
-  const responseMessage = SendEmailResponse.deserialize(responseFileContents);
+  const responseMessage = SendEmailResponse.deserialize(
+    new Uint8Array(responseFileContents),
+  );
   if (responseMessage instanceof Error) {
     throw responseMessage;
   }

--- a/integration_tests/typescript_node/src/assertions.ts
+++ b/integration_tests/typescript_node/src/assertions.ts
@@ -31,7 +31,7 @@ export function assertMatch<O, I>(
   console.log('Bytes from serialization:', arrayBuffer);
   console.log('Size of the serialized message:', arrayBuffer.byteLength);
 
-  writeFileSync(omnifilePath, Buffer.from(arrayBuffer), { flag: 'as' });
+  writeFileSync(omnifilePath, new Uint8Array(arrayBuffer), { flag: 'as' });
 
   const replica = deserialize(arrayBuffer);
   deepStrictEqual(replica, expected);


### PR DESCRIPTION
Summary: Convert Node Buffers to ArrayBuffers before generated deserialization and write ArrayBuffer data via Uint8Array. Tests: toast test_typescript_integration.