### PR TITLE
Bump version to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-04-19
+
+### Changed
+- The TypeScript generator now emits one file per schema, rather than emitting a single file with TypeScript namespaces.
+- The `generate` subcommand now accepts `--rust-file` and `--typescript-dir` instead of `--rust` and `--typescript`, respectively.
+- The generated TypeScript code now includes more type annotations.
+
 ## [0.13.0] - 2026-04-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "typical"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typical"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2024"
 description = "Data interchange with algebraic data types."


### PR DESCRIPTION
Bumps Typical to 0.14.0 and updates the changelog for the TypeScript generator output changes, TypeScript deserialization bound handling, and maintenance updates since 0.13.0.

**Status:** Ready

**Fixes:** N/A

Verification:
- `(cd integration_tests/typescript_web && npm ci && npm run main && open dist/index.html)`
- `cargo build`
- `cargo test`