### PR TITLE
Install v0.14.0 by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
   DESTINATION="${PREFIX:-/usr/local/bin}/typical"
 
   # Which version to download
-  RELEASE="v${VERSION:-0.13.0}"
+  RELEASE="v${VERSION:-0.14.0}"
 
   # Determine which binary to download.
   FILENAME=''


### PR DESCRIPTION
Updates the installer script to download v0.14.0 by default now that the release is published.

**Status:** Ready

**Fixes:** N/A

Verification:
- `gh run view 24642227381 --json status,conclusion,jobs,url`
- `PREFIX=$(mktemp -d /tmp/typical-install-test.XXXXXXXX) ./install.sh`
- `<temp-prefix>/typical --version`