### PR TITLE
Use typed shell completion arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -93,8 +93,8 @@ struct FormatArgs {
 
 #[derive(Args)]
 struct ShellCompletionArgs {
-    #[arg(help = "Bash, Fish, Zsh, PowerShell, or Elvish")]
-    shell: String,
+    #[arg(value_enum, ignore_case = true)]
+    shell: Shell,
 }
 
 #[derive(ClapSubcommand)]
@@ -277,31 +277,10 @@ fn format_schema(schema_path: &Path, check: bool) -> Result<(), Error> {
 }
 
 // Print a shell completion script to STDOUT.
-fn shell_completion(shell: &str) -> Result<(), Error> {
-    // Determine which shell the user wants the shell completion for.
-    let shell_variant = match shell.trim().to_lowercase().as_ref() {
-        "bash" => Shell::Bash,
-        "fish" => Shell::Fish,
-        "zsh" => Shell::Zsh,
-        "powershell" => Shell::PowerShell,
-        "elvish" => Shell::Elvish,
-        _ => {
-            return Err(Error {
-                message: format!(
-                    "Unknown shell {}. Must be one of Bash, Fish, Zsh, PowerShell, or Elvish.",
-                    shell.code_str(),
-                ),
-                reason: None,
-            });
-        }
-    };
-
+fn shell_completion(shell: Shell) {
     // Write the script to STDOUT.
     let mut command = Cli::command();
-    generate(shell_variant, &mut command, BIN_NAME, &mut stdout());
-
-    // If we made it this far, nothing went wrong.
-    Ok(())
+    generate(shell, &mut command, BIN_NAME, &mut stdout());
 }
 
 // Program entrypoint
@@ -326,7 +305,7 @@ fn entry() -> Result<(), Error> {
         }
         TypicalCommand::ShellCompletion(args) => {
             // Generate the shell completion script.
-            shell_completion(&args.shell)?;
+            shell_completion(args.shell);
         }
     }
 


### PR DESCRIPTION
Uses Clap's Shell value enum directly for shell completion arguments, retaining case-insensitive parsing while removing manual validation and conversion.

Validation: toast test_units test_rust_integration test_typescript_integration lint

**Status:** Ready

**Fixes:** N/A