### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     name: Build for Linux
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - if: ${{ github.event_name == 'push' }}
-      uses: docker/login-action@v4.1.0
+      uses: docker/login-action@v4.2.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -79,7 +79,7 @@ jobs:
         # The unit tests do not expect the files in `test_data` to have carriage returns added.
         git config --global core.autocrlf false
         git config --global core.eol lf
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -125,7 +125,7 @@ jobs:
     name: Build for macOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -164,7 +164,7 @@ jobs:
     name: Install on macOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -178,7 +178,7 @@ jobs:
     name: Install on Ubuntu
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -196,8 +196,8 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v6.0.2
-    - uses: docker/login-action@v4.1.0
+    - uses: actions/checkout@v7.0.0
+    - uses: docker/login-action@v4.2.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Update pinned GitHub Actions versions to latest:

- `actions/checkout`: v6.0.2 → v7.0.0
- `docker/login-action`: v4.1.0 → v4.2.0

**Status:** Ready

**Fixes:** N/A