### PR TITLE
Update dependencies

### DIFF
--- a/benchmarks/typescript/package-lock.json
+++ b/benchmarks/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@eslint/js": "10.0.1",
-        "@types/node": "^26.1.0",
+        "@types/node": "^26.1.1",
         "eslint": "^10.6.0",
         "globals": "^17.7.0",
         "prettier": "^3.9.4",
@@ -233,9 +233,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/benchmarks/typescript/package.json
+++ b/benchmarks/typescript/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
-    "@types/node": "^26.1.0",
+    "@types/node": "^26.1.1",
     "eslint": "^10.6.0",
     "globals": "^17.7.0",
     "prettier": "^3.9.4",

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@eslint/js": "10.0.1",
-        "@types/node": "^26.1.0",
+        "@types/node": "^26.1.1",
         "eslint": "^10.6.0",
         "globals": "^17.7.0",
         "prettier": "^3.9.4",
@@ -233,9 +233,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
-    "@types/node": "^26.1.0",
+    "@types/node": "^26.1.1",
     "eslint": "^10.6.0",
     "globals": "^17.7.0",
     "prettier": "^3.9.4",

--- a/integration_tests/typescript_node/package-lock.json
+++ b/integration_tests/typescript_node/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@eslint/js": "10.0.1",
-        "@types/node": "^26.1.0",
+        "@types/node": "^26.1.1",
         "eslint": "^10.6.0",
         "globals": "^17.7.0",
         "prettier": "^3.9.4",
@@ -233,9 +233,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/integration_tests/typescript_node/package.json
+++ b/integration_tests/typescript_node/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
-    "@types/node": "^26.1.0",
+    "@types/node": "^26.1.1",
     "eslint": "^10.6.0",
     "globals": "^17.7.0",
     "prettier": "^3.9.4",


### PR DESCRIPTION
Update @types/node from 26.1.0 to 26.1.1 in the TypeScript benchmark, example, and Node integration-test fixtures. Reviewed the upstream package diff; it only adjusts fs/promises type declarations and package metadata, while this repo uses synchronous fs APIs in these fixtures.

**Status:** Ready

**Fixes:** N/A