### PR TITLE
Make TypeScript import extensions configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-07-09
+
+### Added
+- The `generate` subcommand now accepts `--typescript-import-extension` to configure relative import specifiers in generated TypeScript code.
+
+### Changed
+- The TypeScript generator now emits `.ts` import specifiers by default.
+
 ## [0.15.0] - 2026-04-22
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "typical"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typical"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2024"
 description = "Data interchange with algebraic data types."

--- a/README.md
+++ b/README.md
@@ -697,11 +697,16 @@ Arguments:
   <SCHEMA_PATH>  Set the path to the schema
 
 Options:
-      --list-schemas       List the schemas imported by the given schema (and the given schema
-                           itself)
-      --rust-file <PATH>      Set the path to the Rust file to emit
-      --typescript-dir <PATH>  Set the directory in which the TypeScript files will be emitted
-  -h, --help               Print help
+      --list-schemas
+          List the schemas imported by the given schema (and the given schema itself)
+      --rust-file <PATH>
+          Set the path to the Rust file to emit
+      --typescript-dir <PATH>
+          Set the directory in which the TypeScript files will be emitted
+      --typescript-import-extension <EXTENSION>
+          Set the extension to use in TypeScript import specifiers [default: .ts]
+  -h, --help
+          Print help
 ```
 
 ## Installation instructions

--- a/benchmarks/typescript/package-lock.json
+++ b/benchmarks/typescript/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "benchmark",
       "version": "1.0.0",
+      "type": "module",
       "devDependencies": {
         "@types/node": "^26.1.1",
         "typescript": "6.0.3",

--- a/benchmarks/typescript/package.json
+++ b/benchmarks/typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "benchmark",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "main": "npm run typical && rm -rf dist && tsc --project tsconfig.json && node dist/src/main.js",
     "lint": "npm run typical && vp check",

--- a/benchmarks/typescript/src/main.ts
+++ b/benchmarks/typescript/src/main.ts
@@ -1,6 +1,6 @@
 // oxlint-disable no-console -- The benchmark reports measurements to stdout.
 import { hrtime } from 'node:process';
-import { Message, Struct } from '../generated/types';
+import { Message, Struct } from '../generated/types.ts';
 
 const pathologicalIterations = 5_000;
 const massiveStringSize = 500_000_000;

--- a/benchmarks/typescript/tsconfig.json
+++ b/benchmarks/typescript/tsconfig.json
@@ -5,8 +5,10 @@
     "moduleDetection": "force",
     "outDir": "dist",
     "types": ["node"],
+    "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
+    "rewriteRelativeImportExtensions": true,
     "skipLibCheck": true,
     "strict": true
   },

--- a/benchmarks/typescript/tsconfig.json
+++ b/benchmarks/typescript/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleDetection": "force",
     "outDir": "dist",
     "types": ["node"],
-    "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "rewriteRelativeImportExtensions": true,

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "example",
       "version": "1.0.0",
+      "type": "module",
       "devDependencies": {
         "@types/node": "^26.1.1",
         "typescript": "6.0.3",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "example",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "main": "npm run typical && rm -rf dist && tsc --project tsconfig.json && node dist/src/main.js",
     "lint": "npm run typical && vp check",

--- a/examples/typescript/src/main.ts
+++ b/examples/typescript/src/main.ts
@@ -1,7 +1,7 @@
 // oxlint-disable no-console -- This example prints its observable output to stdout.
 import { readFileSync, unlinkSync, writeFileSync } from 'node:fs';
-import { unreachable } from '../generated/common';
-import { SendEmailRequest, SendEmailResponse } from '../generated/types';
+import { unreachable } from '../generated/common.ts';
+import { SendEmailRequest, SendEmailResponse } from '../generated/types.ts';
 
 const requestFilePath = '/tmp/request';
 const responseFilePath = '/tmp/response';

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -5,8 +5,10 @@
     "moduleDetection": "force",
     "outDir": "dist",
     "types": ["node"],
+    "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
+    "rewriteRelativeImportExtensions": true,
     "skipLibCheck": true,
     "strict": true
   },

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleDetection": "force",
     "outDir": "dist",
     "types": ["node"],
-    "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "rewriteRelativeImportExtensions": true,

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
   DESTINATION="${PREFIX:-/usr/local/bin}/typical"
 
   # Which version to download
-  RELEASE="v${VERSION:-0.16.0}"
+  RELEASE="v${VERSION:-0.15.0}"
 
   # Determine which binary to download.
   FILENAME=''

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
   DESTINATION="${PREFIX:-/usr/local/bin}/typical"
 
   # Which version to download
-  RELEASE="v${VERSION:-0.15.0}"
+  RELEASE="v${VERSION:-0.16.0}"
 
   # Determine which binary to download.
   FILENAME=''

--- a/integration_tests/typescript_node/package-lock.json
+++ b/integration_tests/typescript_node/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "integration-tests",
       "version": "1.0.0",
+      "type": "module",
       "devDependencies": {
         "@types/node": "^26.1.1",
         "typescript": "6.0.3",

--- a/integration_tests/typescript_node/package.json
+++ b/integration_tests/typescript_node/package.json
@@ -1,6 +1,7 @@
 {
   "name": "integration-tests",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "main": "npm run typical && rm -rf dist && tsc --project tsconfig.json && node dist/src/main.js",
     "lint": "npm run typical && vp check",

--- a/integration_tests/typescript_node/src/circular-dependency.ts
+++ b/integration_tests/typescript_node/src/circular-dependency.ts
@@ -1,7 +1,7 @@
 // oxlint-disable no-console -- Integration tests print progress between cases.
-import { StructFromBelow } from '../generated/circular_dependency/dependency/types';
-import { StructFromAbove } from '../generated/circular_dependency/types';
-import { assertRoundTrip } from './assertions';
+import { StructFromBelow } from '../generated/circular_dependency/dependency/types.ts';
+import { StructFromAbove } from '../generated/circular_dependency/types.ts';
+import { assertRoundTrip } from './assertions.ts';
 
 export default function run(): void {
   assertRoundTrip(StructFromAbove.size, StructFromAbove.serialize, StructFromAbove.deserialize, {

--- a/integration_tests/typescript_node/src/comprehensive.ts
+++ b/integration_tests/typescript_node/src/comprehensive.ts
@@ -1,6 +1,6 @@
 // oxlint-disable no-console -- Integration fixtures print diagnostics.
-import { Bar, Foo } from '../generated/comprehensive/types';
-import { assertMatch, assertRoundTrip } from './assertions';
+import { Bar, Foo } from '../generated/comprehensive/types.ts';
+import { assertMatch, assertRoundTrip } from './assertions.ts';
 
 const u64Min = 0n;
 const u64Max = 18_446_744_073_709_551_615n;

--- a/integration_tests/typescript_node/src/degenerate.ts
+++ b/integration_tests/typescript_node/src/degenerate.ts
@@ -4,8 +4,8 @@ import {
   EmptyStruct,
   type EmptyStructIn,
   type EmptyStructOut,
-} from '../generated/degenerate/types';
-import { assertRoundTrip } from './assertions';
+} from '../generated/degenerate/types.ts';
+import { assertRoundTrip } from './assertions.ts';
 
 export function initialIn(x: EmptyChoiceIn): never {
   return x;

--- a/integration_tests/typescript_node/src/main.ts
+++ b/integration_tests/typescript_node/src/main.ts
@@ -1,8 +1,8 @@
 // oxlint-disable no-console -- Integration tests print progress between cases.
-import runCircularDependency from './circular-dependency';
-import runComprehensive from './comprehensive';
-import runDegenerate from './degenerate';
-import runSchemaEvolution from './schema-evolution';
+import runCircularDependency from './circular-dependency.ts';
+import runComprehensive from './comprehensive.ts';
+import runDegenerate from './degenerate.ts';
+import runSchemaEvolution from './schema-evolution.ts';
 
 console.log('Running circular dependency integration test\u2026\n');
 runCircularDependency();

--- a/integration_tests/typescript_node/src/schema-evolution.ts
+++ b/integration_tests/typescript_node/src/schema-evolution.ts
@@ -3,14 +3,14 @@ import {
   ExampleChoice as AfterExampleChoice,
   type ExampleChoiceIn as AfterExampleChoiceIn,
   ExampleStruct as AfterExampleStruct,
-} from '../generated/schema_evolution/after';
+} from '../generated/schema_evolution/after.ts';
 import {
   ExampleChoice as BeforeExampleChoice,
   type ExampleChoiceOut as BeforeExampleChoiceOut,
   ExampleStruct as BeforeExampleStruct,
-} from '../generated/schema_evolution/before';
-import { SingletonChoice, SingletonStruct } from '../generated/schema_evolution/types';
-import { assertMatch } from './assertions';
+} from '../generated/schema_evolution/before.ts';
+import { SingletonChoice, SingletonStruct } from '../generated/schema_evolution/types.ts';
+import { assertMatch } from './assertions.ts';
 
 function choiceTestCases(
   fallbackBefore: BeforeExampleChoiceOut,

--- a/integration_tests/typescript_node/tsconfig.json
+++ b/integration_tests/typescript_node/tsconfig.json
@@ -5,8 +5,10 @@
     "moduleDetection": "force",
     "outDir": "dist",
     "types": ["node"],
+    "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
+    "rewriteRelativeImportExtensions": true,
     "skipLibCheck": true,
     "strict": true
   },

--- a/integration_tests/typescript_node/tsconfig.json
+++ b/integration_tests/typescript_node/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleDetection": "force",
     "outDir": "dist",
     "types": ["node"],
-    "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "rewriteRelativeImportExtensions": true,

--- a/integration_tests/typescript_web/package-lock.json
+++ b/integration_tests/typescript_web/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "integration-tests",
       "version": "1.0.0",
+      "type": "module",
       "dependencies": {
         "js-sha256": "0.11.1",
         "lodash": "4.18.1"

--- a/integration_tests/typescript_web/package.json
+++ b/integration_tests/typescript_web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "integration-tests",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "main": "npm run typical && rm -rf dist && tsc --project tsconfig.json && vp build",
     "lint": "npm run typical && vp check",

--- a/integration_tests/typescript_web/src/circular-dependency.ts
+++ b/integration_tests/typescript_web/src/circular-dependency.ts
@@ -1,7 +1,7 @@
 // oxlint-disable no-console -- Integration tests print progress between cases.
-import { StructFromBelow } from '../generated/circular_dependency/dependency/types';
-import { StructFromAbove } from '../generated/circular_dependency/types';
-import { assertRoundTrip } from './assertions';
+import { StructFromBelow } from '../generated/circular_dependency/dependency/types.ts';
+import { StructFromAbove } from '../generated/circular_dependency/types.ts';
+import { assertRoundTrip } from './assertions.ts';
 
 export default function run(): void {
   assertRoundTrip(StructFromAbove.size, StructFromAbove.serialize, StructFromAbove.deserialize, {

--- a/integration_tests/typescript_web/src/comprehensive.ts
+++ b/integration_tests/typescript_web/src/comprehensive.ts
@@ -1,6 +1,6 @@
 // oxlint-disable no-console -- Integration fixtures print diagnostics.
-import { Bar, Foo } from '../generated/comprehensive/types';
-import { assertMatch, assertRoundTrip } from './assertions';
+import { Bar, Foo } from '../generated/comprehensive/types.ts';
+import { assertMatch, assertRoundTrip } from './assertions.ts';
 
 const u64Min = 0n;
 const u64Max = 18_446_744_073_709_551_615n;

--- a/integration_tests/typescript_web/src/degenerate.ts
+++ b/integration_tests/typescript_web/src/degenerate.ts
@@ -4,8 +4,8 @@ import {
   EmptyStruct,
   type EmptyStructIn,
   type EmptyStructOut,
-} from '../generated/degenerate/types';
-import { assertRoundTrip } from './assertions';
+} from '../generated/degenerate/types.ts';
+import { assertRoundTrip } from './assertions.ts';
 
 export function initialIn(x: EmptyChoiceIn): never {
   return x;

--- a/integration_tests/typescript_web/src/main.ts
+++ b/integration_tests/typescript_web/src/main.ts
@@ -1,9 +1,9 @@
 // oxlint-disable no-console -- Integration tests print progress between cases.
-import runCircularDependency from './circular-dependency';
-import runComprehensive from './comprehensive';
-import runDegenerate from './degenerate';
-import runSchemaEvolution from './schema-evolution';
-import { verifyOmnifile } from './assertions';
+import runCircularDependency from './circular-dependency.ts';
+import runComprehensive from './comprehensive.ts';
+import runDegenerate from './degenerate.ts';
+import runSchemaEvolution from './schema-evolution.ts';
+import { verifyOmnifile } from './assertions.ts';
 
 function setStatus(message: string): void {
   const app = document.querySelector<HTMLDivElement>('#app');

--- a/integration_tests/typescript_web/src/schema-evolution.ts
+++ b/integration_tests/typescript_web/src/schema-evolution.ts
@@ -3,14 +3,14 @@ import {
   ExampleChoice as AfterExampleChoice,
   type ExampleChoiceIn as AfterExampleChoiceIn,
   ExampleStruct as AfterExampleStruct,
-} from '../generated/schema_evolution/after';
+} from '../generated/schema_evolution/after.ts';
 import {
   ExampleChoice as BeforeExampleChoice,
   type ExampleChoiceOut as BeforeExampleChoiceOut,
   ExampleStruct as BeforeExampleStruct,
-} from '../generated/schema_evolution/before';
-import { SingletonChoice, SingletonStruct } from '../generated/schema_evolution/types';
-import { assertMatch } from './assertions';
+} from '../generated/schema_evolution/before.ts';
+import { SingletonChoice, SingletonStruct } from '../generated/schema_evolution/types.ts';
+import { assertMatch } from './assertions.ts';
 
 function choiceTestCases(
   fallbackBefore: BeforeExampleChoiceOut,

--- a/integration_tests/typescript_web/tsconfig.json
+++ b/integration_tests/typescript_web/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "types": ["vite-plus/client"],
+    "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/src/generate_typescript.rs
+++ b/src/generate_typescript.rs
@@ -143,6 +143,7 @@ impl DeclarationFunctionNames {
 pub fn generate(
     typical_version: &str,
     schemas: &BTreeMap<schema::Namespace, (schema::Schema, PathBuf, String)>,
+    import_extension: &str,
 ) -> BTreeMap<PathBuf, String> {
     let mut files = BTreeMap::new();
 
@@ -157,7 +158,14 @@ pub fn generate(
     for (namespace, (schema, _, _)) in schemas {
         let mut buffer = String::new();
         // The `unwrap` is safe because the `std::fmt::Write` impl for `String` is infallible.
-        write_schema_file(&mut buffer, typical_version, namespace, schema).unwrap();
+        write_schema_file(
+            &mut buffer,
+            typical_version,
+            namespace,
+            schema,
+            import_extension,
+        )
+        .unwrap();
         let mut path = PathBuf::new();
         for component in &namespace.components {
             path.push(component.snake_case());
@@ -510,6 +518,7 @@ fn write_schema_file<T: Write>(
     typical_version: &str,
     namespace: &schema::Namespace,
     schema: &schema::Schema,
+    import_extension: &str,
 ) -> Result<(), fmt::Error> {
     write_generated_file_header(buffer, typical_version)?;
 
@@ -518,7 +527,7 @@ fn write_schema_file<T: Write>(
     }
 
     writeln!(buffer)?;
-    write_common_import(buffer, namespace)?;
+    write_common_import(buffer, namespace, import_extension)?;
 
     if !schema.imports.is_empty() {
         writeln!(buffer)?;
@@ -534,6 +543,7 @@ fn write_schema_file<T: Write>(
                     .iter()
                     .map(Identifier::snake_case)
                     .collect::<Vec<_>>(),
+                import_extension,
             );
             writeln!(buffer, "import * as {binding_name} from '{specifier}';")?;
         }
@@ -549,10 +559,12 @@ fn write_schema_file<T: Write>(
 fn write_common_import<T: Write>(
     buffer: &mut T,
     namespace: &schema::Namespace,
+    import_extension: &str,
 ) -> Result<(), fmt::Error> {
     let specifier = relative_module_specifier(
         &namespace_parent_components(namespace),
         &[COMMON_FILE_STEM.to_owned()],
+        import_extension,
     );
 
     writeln!(
@@ -2575,7 +2587,11 @@ fn namespace_parent_components(namespace: &schema::Namespace) -> Vec<String> {
 }
 
 // Compute a relative TypeScript module specifier between component paths.
-fn relative_module_specifier(from_directory: &[String], to: &[String]) -> String {
+fn relative_module_specifier(
+    from_directory: &[String],
+    to: &[String],
+    import_extension: &str,
+) -> String {
     let common_components = from_directory
         .iter()
         .zip(to.iter())
@@ -2596,7 +2612,7 @@ fn relative_module_specifier(from_directory: &[String], to: &[String]) -> String
         components.push(component.clone());
     }
 
-    components.join("/")
+    format!("{}{}", components.join("/"), import_extension)
 }
 
 // Format an import name as a private TypeScript namespace binding.
@@ -2643,7 +2659,7 @@ mod tests {
             expected.insert(path, contents);
         }
 
-        assert_eq!(generate("0.0.0", &schemas), expected);
+        assert_eq!(generate("0.0.0", &schemas, ".ts"), expected);
     }
 
     // Check that TypeScript file paths and import specifiers use `snake_case`.
@@ -2698,7 +2714,7 @@ mod tests {
             ),
         );
 
-        let generated = generate("0.0.0", &schemas);
+        let generated = generate("0.0.0", &schemas, ".ts");
 
         assert!(generated.contains_key(Path::new("foo/first_schema.ts")));
         assert!(generated.contains_key(Path::new("bar/second_schema.ts")));
@@ -2706,7 +2722,37 @@ mod tests {
             generated
                 .get(Path::new("bar/second_schema.ts"))
                 .unwrap()
-                .contains("import * as _FirstSchema from '../foo/first_schema';"),
+                .contains("import * as _FirstSchema from '../foo/first_schema.ts';"),
+        );
+    }
+
+    #[test]
+    fn generate_javascript_import_extension() {
+        let schemas = load_schemas(Path::new("integration_tests/types/types.t")).unwrap();
+        validate(&schemas).unwrap();
+
+        let generated = generate("0.0.0", &schemas, ".js");
+
+        assert!(
+            generated
+                .get(Path::new("schema_evolution/types.ts"))
+                .unwrap()
+                .contains("import * as _After from './after.js';"),
+        );
+    }
+
+    #[test]
+    fn generate_extensionless_imports() {
+        let schemas = load_schemas(Path::new("integration_tests/types/types.t")).unwrap();
+        validate(&schemas).unwrap();
+
+        let generated = generate("0.0.0", &schemas, "");
+
+        assert!(
+            generated
+                .get(Path::new("schema_evolution/types.ts"))
+                .unwrap()
+                .contains("import * as _After from './after';"),
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,14 @@ struct GenerateArgs {
         help = "Set the directory in which the TypeScript files will be emitted"
     )]
     typescript_dir: Option<PathBuf>,
+
+    #[arg(
+        long,
+        default_value = ".ts",
+        value_name = "EXTENSION",
+        help = "Set the extension to use in TypeScript import specifiers"
+    )]
+    typescript_import_extension: String,
 }
 
 #[derive(Args)]
@@ -118,6 +126,7 @@ fn generate_code(
     list_schemas: bool,
     rust_file: Option<&Path>,
     typescript_directory: Option<&Path>,
+    typescript_import_extension: &str,
 ) -> Result<(), Error> {
     // Load the schema and its transitive dependencies.
     eprintln!("Loading schemas\u{2026}");
@@ -173,10 +182,25 @@ fn generate_code(
 
     // Generate TypeScript code, if applicable.
     if let Some(typescript_directory) = typescript_directory {
+        if !typescript_import_extension.is_empty() && !typescript_import_extension.starts_with('.')
+        {
+            return Err(throw::<Error>(
+                &format!(
+                    "The TypeScript import extension {} must be empty or start with a dot.",
+                    typescript_import_extension.code_str(),
+                ),
+                None,
+                None,
+                None,
+            ));
+        }
+
         eprintln!("Generating TypeScript\u{2026}");
 
         // Generate the code and write it to the files.
-        for (relative_path, contents) in generate_typescript::generate(VERSION, &schemas) {
+        for (relative_path, contents) in
+            generate_typescript::generate(VERSION, &schemas, typescript_import_extension)
+        {
             let output_file_path = typescript_directory.join(&relative_path);
 
             // Create any missing ancestor directories.
@@ -297,6 +321,7 @@ fn entry() -> Result<(), Error> {
                 args.list_schemas,
                 args.rust_file.as_deref(),
                 args.typescript_dir.as_deref(),
+                &args.typescript_import_extension,
             )?;
         }
         TypicalCommand::Format(args) => {

--- a/test_data/typescript/circular_dependency/dependency/types.ts
+++ b/test_data/typescript/circular_dependency/dependency/types.ts
@@ -18,10 +18,10 @@ import {
   varintSizeFromValue,
   zigzagDecode,
   zigzagEncode,
-} from '../../common';
-import type { Deserializable } from '../../common';
+} from '../../common.ts';
+import type { Deserializable } from '../../common.ts';
 
-import * as _Types from '../types';
+import * as _Types from '../types.ts';
 
 export type StructFromBelowAtlas = {
   $size: number;

--- a/test_data/typescript/circular_dependency/types.ts
+++ b/test_data/typescript/circular_dependency/types.ts
@@ -18,10 +18,10 @@ import {
   varintSizeFromValue,
   zigzagDecode,
   zigzagEncode,
-} from '../common';
-import type { Deserializable } from '../common';
+} from '../common.ts';
+import type { Deserializable } from '../common.ts';
 
-import * as _Types from './dependency/types';
+import * as _Types from './dependency/types.ts';
 
 export type StructFromAboveAtlas = {
   $size: number;

--- a/test_data/typescript/comprehensive/types.ts
+++ b/test_data/typescript/comprehensive/types.ts
@@ -18,10 +18,10 @@ import {
   varintSizeFromValue,
   zigzagDecode,
   zigzagEncode,
-} from '../common';
-import type { Deserializable } from '../common';
+} from '../common.ts';
+import type { Deserializable } from '../common.ts';
 
-import * as _Types from '../degenerate/types';
+import * as _Types from '../degenerate/types.ts';
 
 export type LocalStructAtlas = {
   $size: number;

--- a/test_data/typescript/degenerate/types.ts
+++ b/test_data/typescript/degenerate/types.ts
@@ -18,8 +18,8 @@ import {
   varintSizeFromValue,
   zigzagDecode,
   zigzagEncode,
-} from '../common';
-import type { Deserializable } from '../common';
+} from '../common.ts';
+import type { Deserializable } from '../common.ts';
 
 export type EmptyStructAtlas = {
   $size: number;

--- a/test_data/typescript/schema_evolution/after.ts
+++ b/test_data/typescript/schema_evolution/after.ts
@@ -18,8 +18,8 @@ import {
   varintSizeFromValue,
   zigzagDecode,
   zigzagEncode,
-} from '../common';
-import type { Deserializable } from '../common';
+} from '../common.ts';
+import type { Deserializable } from '../common.ts';
 
 export type ExampleStructAtlas = {
   $size: number;

--- a/test_data/typescript/schema_evolution/before.ts
+++ b/test_data/typescript/schema_evolution/before.ts
@@ -18,8 +18,8 @@ import {
   varintSizeFromValue,
   zigzagDecode,
   zigzagEncode,
-} from '../common';
-import type { Deserializable } from '../common';
+} from '../common.ts';
+import type { Deserializable } from '../common.ts';
 
 export type ExampleStructAtlas = {
   $size: number;

--- a/test_data/typescript/schema_evolution/types.ts
+++ b/test_data/typescript/schema_evolution/types.ts
@@ -18,11 +18,11 @@ import {
   varintSizeFromValue,
   zigzagDecode,
   zigzagEncode,
-} from '../common';
-import type { Deserializable } from '../common';
+} from '../common.ts';
+import type { Deserializable } from '../common.ts';
 
-import * as _After from './after';
-import * as _Before from './before';
+import * as _After from './after.ts';
+import * as _Before from './before.ts';
 
 export type SingletonStructAtlas = {
   $size: number;


### PR DESCRIPTION
Make TypeScript generation emit configurable relative import extensions. The default is now `.ts`, with `--typescript-import-extension` accepting values like `.js` or an empty string for extensionless imports.

The TypeScript example, benchmark, and integration packages now use package-level ESM with `.ts` source imports. Node-emitting packages enable TypeScript's relative import rewriting so compiled JavaScript still imports `.js` files at runtime.

**Status:** Ready

**Fixes:** N/A
