### PR TITLE
Install Typical 0.16.0 by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
   DESTINATION="${PREFIX:-/usr/local/bin}/typical"
 
   # Which version to download
-  RELEASE="v${VERSION:-0.15.0}"
+  RELEASE="v${VERSION:-0.16.0}"
 
   # Determine which binary to download.
   FILENAME=''


### PR DESCRIPTION
Update the installer's default release from `v0.15.0` to `v0.16.0` now that the release has been published.

**Status:** Ready

**Fixes:** N/A
