### PR TITLE
Remove redundant web dist cleanup

### DIFF
--- a/integration_tests/typescript_web/package.json
+++ b/integration_tests/typescript_web/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "main": "npm run typical && rm -rf dist && tsc --project tsconfig.json && vp build",
+    "main": "npm run typical && tsc --project tsconfig.json && vp build",
     "lint": "npm run typical && vp check",
     "format": "vp fmt && typical format ../types/types.t",
     "typical": "(cd ../.. && cargo run -- generate integration_tests/types/types.t --typescript-dir integration_tests/typescript_web/generated)",
-    "serve": "npm run typical && rm -rf dist && tsc --project tsconfig.json && vp dev"
+    "serve": "npm run typical && tsc --project tsconfig.json && vp dev"
   },
   "dependencies": {
     "js-sha256": "0.11.1",


### PR DESCRIPTION
Remove the explicit `dist` cleanup from the TypeScript web integration scripts. This project only type-checks with TypeScript and leaves output cleanup to Vite Plus.

**Status:** Ready

**Fixes:** N/A