### PR TITLE
Enable verbatim TypeScript module syntax

### DIFF
--- a/benchmarks/typescript/tsconfig.json
+++ b/benchmarks/typescript/tsconfig.json
@@ -9,7 +9,8 @@
     "noFallthroughCasesInSwitch": true,
     "rewriteRelativeImportExtensions": true,
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src", "vite.config.ts"]
 }

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -9,7 +9,8 @@
     "noFallthroughCasesInSwitch": true,
     "rewriteRelativeImportExtensions": true,
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src", "vite.config.ts"]
 }

--- a/integration_tests/typescript_node/tsconfig.json
+++ b/integration_tests/typescript_node/tsconfig.json
@@ -9,7 +9,8 @@
     "noFallthroughCasesInSwitch": true,
     "rewriteRelativeImportExtensions": true,
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src", "vite.config.ts"]
 }


### PR DESCRIPTION
Enable `verbatimModuleSyntax` in the remaining TypeScript configs so Node and web TypeScript projects use consistent module emit behavior.

**Status:** Ready

**Fixes:** N/A