### PR TITLE
Update dependencies

### DIFF
--- a/integration_tests/typescript_web/package-lock.json
+++ b/integration_tests/typescript_web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "integration-tests",
       "version": "1.0.0",
       "dependencies": {
-        "js-sha256": "0.11.1",
+        "js-sha256": "^0.12.0",
         "lodash": "4.18.1"
       },
       "devDependencies": {
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/js-sha256": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
-      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.12.0.tgz",
+      "integrity": "sha512-P2IyTRMIHCkLD9clcQST8wGP/wqOXjvDD7E3onloE/5LSQGscyrmk2Loa069YsdtLfQWN1EnMDiaomAs9AfP4w==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {

--- a/integration_tests/typescript_web/package.json
+++ b/integration_tests/typescript_web/package.json
@@ -10,7 +10,7 @@
     "serve": "npm run typical && tsc --project tsconfig.json && vp dev"
   },
   "dependencies": {
-    "js-sha256": "0.11.1",
+    "js-sha256": "^0.12.0",
     "lodash": "4.18.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the TypeScript web integration-test dependency:

- `js-sha256` 0.11.1 -> 0.12.0, replacing the exact pin with a caret range

Changelog review: `js-sha256` 0.12.0 includes packaging/ESM and environment-detection updates. No code changes were required. Rust, GitHub Actions, submodules, and copyright year were already current.

**Status:** Ready

**Fixes:** N/A