### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -147,9 +147,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "libc"
-version = "0.2.187"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -162,15 +162,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "pad"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
-dependencies = [
- "unicode-width 0.1.14",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -217,9 +208,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.119"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -244,7 +235,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -254,7 +245,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "colored",
- "pad",
  "textwrap",
  "unicode-segmentation",
 ]
@@ -276,12 +266,6 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,8 @@ clippy.pedantic = { level = "deny", priority = -1 }
 rust.warnings = "deny"
 
 [dependencies]
-clap = { version = "4.6.3", features = ["derive", "wrap_help"] }
+clap = { version = "4.6.4", features = ["derive", "wrap_help"] }
 clap_complete = "4.6.7"
 colored = "3.1.1"
-pad = "0.1.6"
 textwrap = "0.16.2"
 unicode-segmentation = "1.13.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 use crate::format::CodeStr;
 use colored::{Colorize, control::SHOULD_COLORIZE};
-use pad::{Alignment, PadStr};
 use std::{
     cmp::{max, min},
     error, fmt,
@@ -162,12 +161,9 @@ pub fn listing(source_contents: &str, source_range: SourceRange) -> String {
         .map(|(i, (line_number, line, section_start, section_end))| {
             format!(
                 "{}{}{}{}{}",
-                format!(
-                    "{} \u{2502} ",
-                    line_number.pad(gutter_width, ' ', Alignment::Right, false),
-                )
-                .blue()
-                .bold(),
+                format!("{line_number:>gutter_width$} \u{2502} ")
+                    .blue()
+                    .bold(),
                 &line[..*section_start],
                 line[*section_start..*section_end].red(),
                 &line[*section_end..],


### PR DESCRIPTION
Update Clap from 4.6.3 to 4.6.4 and refresh transitive lockfile entries (`clap_derive` 4.6.3 → 4.6.4, `libc` 0.2.187 → 0.2.189, and `syn` 2.0.119 → 3.0.3). Clap 4.6.4’s only change is its internal migration to syn 3; Typical does not use syn directly, so no compatibility adaptation is needed. The libc updates are additive/fix releases.

Remove the dormant `pad` 0.1.6 dependency (last crate release in 2019) and its obsolete `unicode-width` 0.1 transitive dependency. Its sole use right-aligned numeric line numbers and is replaced directly with Rust’s standard formatting syntax, preserving output while reducing dependencies. No other dependency-health issue requires a migration.

Rust 1.97.1, nightly rustfmt 2026-07-18, GitHub Actions, and the 2026 license year were already current. This repository has no git submodules.

Native verification passed with Rust 1.97.1 (`cargo build`, 215 unit tests, and Clippy). Canonical verification passed with `toast build`, `toast test_units`, `toast test_rust_integration`, `toast test_typescript_integration`, and `toast lint`, including Rust and TypeScript generator scenarios, tagref, shellcheck, Clippy, and rustfmt.

**Status:** Ready

**Fixes:** N/A