### PR TITLE
Install the latest release by default

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,9 +30,8 @@ The GitHub workflow will fail initially because the jobs which test the installe
 
 ### Release instructions
 
-Releasing a new version is a four-step process:
+Releasing a new version is a three-step process:
 
 1. Run `(cd integration_tests/typescript_web && npm ci && npm run serve)` and open [http://localhost:5173/](http://localhost:5173/) in a browser to run the browser-based integration tests. This is the only test suite that doesn't run in the GitHub workflow.
-2. Bump the version in `[file:Cargo.toml]`, run `cargo build` to update `[file:Cargo.lock]`, and update `[file:CHANGELOG.md]` with information about the new version. Ship those changes as a single commit.
-3. Once the GitHub workflow has finished on the `main` branch, update the version in `[file:install.sh]` to point to the new release.
-4. Create a pull request in the `Homebrew/homebrew-core` repository on GitHub to bump the version in [this file](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/t/typical.rb).
+2. Bump the version in `[file:Cargo.toml]`, run `cargo build` to update `[file:Cargo.lock]`, and update `[file:CHANGELOG.md]` with information about the new version. Ship those changes as a single commit. Once the GitHub workflow publishes the release, the installation script will begin installing it by default.
+3. Create a pull request in the `Homebrew/homebrew-core` repository on GitHub to bump the version in [this file](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/t/typical.rb).

--- a/install.sh
+++ b/install.sh
@@ -13,9 +13,6 @@
   # Where the binary will be installed
   DESTINATION="${PREFIX:-/usr/local/bin}/typical"
 
-  # Which version to download
-  RELEASE="v${VERSION:-0.16.0}"
-
   # Determine which binary to download.
   FILENAME=''
   if uname -a | grep -qi 'x86_64.*GNU/Linux'; then
@@ -56,10 +53,15 @@
   # Compute the full file path.
   SOURCE="$TEMPDIR/$FILENAME"
 
+  # Download the requested version, or the latest published version by default.
+  if [ -n "${VERSION:-}" ]; then
+    DOWNLOAD_URL="https://github.com/stepchowfun/typical/releases/download/v$VERSION/$FILENAME"
+  else
+    DOWNLOAD_URL="https://github.com/stepchowfun/typical/releases/latest/download/$FILENAME"
+  fi
+
   # Download the binary.
-  curl \
-    "https://github.com/stepchowfun/typical/releases/download/$RELEASE/$FILENAME" \
-    -o "$SOURCE" -LSf || fail 'There was an error downloading the binary.'
+  curl "$DOWNLOAD_URL" -o "$SOURCE" -LSf || fail 'There was an error downloading the binary.'
 
   # Make it executable.
   chmod a+x "$SOURCE" || fail 'There was an error setting the permissions for the binary.'


### PR DESCRIPTION
Use the latest published GitHub release when `VERSION` is not set, while preserving explicit version selection with `VERSION=x.y.z`. This removes the follow-up installer bump from the release process.

**Status:** Ready

**Fixes:** N/A
