### PR TITLE
Update dependencies and GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7.0.1
     - if: ${{ github.event_name == 'push' }}
-      uses: docker/login-action@v4.5.1
+      uses: docker/login-action@v4.6.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -197,7 +197,7 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v7.0.1
-    - uses: docker/login-action@v4.5.1
+    - uses: docker/login-action@v4.6.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ clippy.pedantic = { level = "deny", priority = -1 }
 rust.warnings = "deny"
 
 [dependencies]
-clap = { version = "4.6.4", features = ["derive", "wrap_help"] }
-clap_complete = "4.6.7"
+clap = { version = "4.6.5", features = ["derive", "wrap_help"] }
+clap_complete = "4.6.8"
 colored = "3.1.1"
 textwrap = "0.16.2"
 unicode-segmentation = "1.13.3"

--- a/benchmarks/typescript/package-lock.json
+++ b/benchmarks/typescript/package-lock.json
@@ -8,9 +8,9 @@
       "name": "benchmark",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "typescript": "^7.0.2",
-        "vite-plus": "^0.2.6"
+        "vite-plus": "^0.2.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -954,9 +954,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1458,9 +1458,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-core": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
-      "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.7.tgz",
+      "integrity": "sha512-zqaBkM1XZ4IHvFJlG2uv7kQF+dqtUcxXSPGyn15BXRfQb101HPpXXe6PHi7YOmZmbQd+hnwNr5+aklXSriZhVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1551,9 +1551,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-darwin-arm64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.6.tgz",
-      "integrity": "sha512-QSZWgfqPx5lrIKZ0vwgVRujRqo7gORcc9Oq4fI1UDjKZFgYz9gXVMibSjEqYU3R1webN6FKTOCnzFmrfXchWYw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.7.tgz",
+      "integrity": "sha512-1DsMuysinq4aDiM4212sp5vdDeBPZPdiWwOOZcAl2AVq25hhqDEHdken/PXKHmiXg8M2FGdydpcUtxR5kwdetg==",
       "cpu": [
         "arm64"
       ],
@@ -1568,9 +1568,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-darwin-x64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.6.tgz",
-      "integrity": "sha512-pMQZGCQO0s+akuxbjgh31hOUgrdDndCmfbP7BciJuts436qrBb8KaVzBhNjJQtxD6H8yY21CIOjD8nlrp4eDIw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.7.tgz",
+      "integrity": "sha512-ZYSau3poUyX1qPmxYzFuHtGIE7T0zI8KDY/oAXoDBb5M2HSd+uu0ov6jNETkBphMlcSmQ/lT+FFlAkCBZklpqg==",
       "cpu": [
         "x64"
       ],
@@ -1585,9 +1585,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-arm64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.6.tgz",
-      "integrity": "sha512-0e6nrJgUDN5WwoDRjyh7KV/jbL7WDUhTEWslI64KGpuvD7M6OoPBXYo8Et176O2ENwf52CKVDjXwuvMMNIAzAA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.7.tgz",
+      "integrity": "sha512-7cpZOsHb6nuX6kRCXwWtzBxxJmCVrPcBe/H4q6n1yhWDtqZp/YY05CdFh458V7qUmIKIl70iA5vQ4M9qLPgYcA==",
       "cpu": [
         "arm64"
       ],
@@ -1605,9 +1605,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-arm64-musl": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.6.tgz",
-      "integrity": "sha512-j2yvyv3r2ZEuJG73rWlXFrYrxA7u5+bFSlWTqhsfHZhdb1FKMkklfYRuLtBBdBRLXJ+YMNt9GZT6VTVPJDZnnQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.7.tgz",
+      "integrity": "sha512-Aaqm3rlIr6qV2CdQjkyBceQqUlBpvvhGjKfpdAWhPaur4nN44gmjky88vMqL/1R6pieCdfAtUw4a6IVQ/Dq5VQ==",
       "cpu": [
         "arm64"
       ],
@@ -1625,9 +1625,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-x64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.6.tgz",
-      "integrity": "sha512-5vqldBBnRjIAUmQ88oKli+wPd5vSQaA2AZ2xs+omRlZfeJhC8chlud6DyJV6fVZCC9GI4otK2zSGpfQZx8Kc3A==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.7.tgz",
+      "integrity": "sha512-LSdD1ID4Mdufckk/Oc+IzhyXCFFUVGR+teiToQNzhD3aoEhrJQMKarx/Ea+dInRdBTNmioAL2xT1R2HP9a+HOA==",
       "cpu": [
         "x64"
       ],
@@ -1645,9 +1645,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-x64-musl": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.6.tgz",
-      "integrity": "sha512-29ned+euDKAl+BmCigzGrPykQ/kxTjtsPGV6G3hkImwakHNUnmLRayqmsWKHSwXmBk5xo5m+wqjMbo3G0npJQg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.7.tgz",
+      "integrity": "sha512-0SwXa8XyagGcyCfjYr6vrOCcEJ37VCvO8MV1y0HVjcO+eqH399NgWNvHRUHiA2baiWQeBBBB+B9WyCpdpKSiag==",
       "cpu": [
         "x64"
       ],
@@ -1665,9 +1665,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-win32-arm64-msvc": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.6.tgz",
-      "integrity": "sha512-4b5ASpQlkxSXDYzuM6MYsOc1GnYkqG9CbSA1QzobXm87V/Q+MGPn57eILyacgfbmNNLrO2HQ5hasoLvd2BXaSg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.7.tgz",
+      "integrity": "sha512-99spn9NEABFyn2lCrZL1nfpX06HhDNyWfZvX+e8zvSqV4LP2td2O4jI6St6KjuwVrK0VveNI/vwzJAe3CSGbzQ==",
       "cpu": [
         "arm64"
       ],
@@ -1682,9 +1682,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-win32-x64-msvc": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.6.tgz",
-      "integrity": "sha512-rvGkm4WmVkCKPhvUbLkRtlVhi7EYb8GU8KaqIGJ0dVfNQHDEqnFboaiUHuPN1npFNwB+80Ulzz9AkQ/Q8MswQA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.7.tgz",
+      "integrity": "sha512-Qe5XZLntwivz2fc1POrJnN6vIYGPcNks5q+GHPaCmYUtIBmAx53ME9OC/tLPpfno2jlZAHLy1vLAirkMVzvrwA==",
       "cpu": [
         "x64"
       ],
@@ -2878,9 +2878,9 @@
     },
     "node_modules/vite": {
       "name": "@voidzero-dev/vite-plus-core",
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
-      "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.7.tgz",
+      "integrity": "sha512-zqaBkM1XZ4IHvFJlG2uv7kQF+dqtUcxXSPGyn15BXRfQb101HPpXXe6PHi7YOmZmbQd+hnwNr5+aklXSriZhVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2971,9 +2971,9 @@
       }
     },
     "node_modules/vite-plus": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.6.tgz",
-      "integrity": "sha512-fFX8GLENhtzvnE4NmTPC8INRxjD2kZKcqUW0p7jOdawmHTNZqM5FiieyWOG6WH1a/axu9FCsbUNb918grfzDTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.7.tgz",
+      "integrity": "sha512-4xFo1nDtH/isWBdJaCgmctMiNohbuxa0uiKA/cbpL8jT18Ax73Lt6rK20/LkqPG5a/HpvPNhDCS1QK58pH4txA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2988,7 +2988,7 @@
         "@vitest/snapshot": "4.1.10",
         "@vitest/spy": "4.1.10",
         "@vitest/utils": "4.1.10",
-        "@voidzero-dev/vite-plus-core": "0.2.6",
+        "@voidzero-dev/vite-plus-core": "0.2.7",
         "oxfmt": "=0.60.0",
         "oxlint": "=1.75.0",
         "oxlint-tsgolint": "=7.0.2001",
@@ -3004,14 +3004,14 @@
         "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
       },
       "optionalDependencies": {
-        "@voidzero-dev/vite-plus-darwin-arm64": "0.2.6",
-        "@voidzero-dev/vite-plus-darwin-x64": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.6",
-        "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.6",
-        "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.6"
+        "@voidzero-dev/vite-plus-darwin-arm64": "0.2.7",
+        "@voidzero-dev/vite-plus-darwin-x64": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.7",
+        "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.7",
+        "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.7"
       },
       "peerDependencies": {
         "@vitest/browser-playwright": "4.1.10",

--- a/benchmarks/typescript/package.json
+++ b/benchmarks/typescript/package.json
@@ -9,11 +9,11 @@
     "typical": "(cd ../.. && cargo run -- generate benchmarks/types.t --typescript-dir benchmarks/typescript/generated)"
   },
   "devDependencies": {
-    "@types/node": "^26.1.1",
+    "@types/node": "^26.1.2",
     "typescript": "^7.0.2",
-    "vite-plus": "^0.2.6"
+    "vite-plus": "^0.2.7"
   },
   "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.2.6"
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.2.7"
   }
 }

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -8,9 +8,9 @@
       "name": "example",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "typescript": "^7.0.2",
-        "vite-plus": "^0.2.6"
+        "vite-plus": "^0.2.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -954,9 +954,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1458,9 +1458,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-core": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
-      "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.7.tgz",
+      "integrity": "sha512-zqaBkM1XZ4IHvFJlG2uv7kQF+dqtUcxXSPGyn15BXRfQb101HPpXXe6PHi7YOmZmbQd+hnwNr5+aklXSriZhVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1551,9 +1551,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-darwin-arm64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.6.tgz",
-      "integrity": "sha512-QSZWgfqPx5lrIKZ0vwgVRujRqo7gORcc9Oq4fI1UDjKZFgYz9gXVMibSjEqYU3R1webN6FKTOCnzFmrfXchWYw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.7.tgz",
+      "integrity": "sha512-1DsMuysinq4aDiM4212sp5vdDeBPZPdiWwOOZcAl2AVq25hhqDEHdken/PXKHmiXg8M2FGdydpcUtxR5kwdetg==",
       "cpu": [
         "arm64"
       ],
@@ -1568,9 +1568,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-darwin-x64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.6.tgz",
-      "integrity": "sha512-pMQZGCQO0s+akuxbjgh31hOUgrdDndCmfbP7BciJuts436qrBb8KaVzBhNjJQtxD6H8yY21CIOjD8nlrp4eDIw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.7.tgz",
+      "integrity": "sha512-ZYSau3poUyX1qPmxYzFuHtGIE7T0zI8KDY/oAXoDBb5M2HSd+uu0ov6jNETkBphMlcSmQ/lT+FFlAkCBZklpqg==",
       "cpu": [
         "x64"
       ],
@@ -1585,9 +1585,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-arm64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.6.tgz",
-      "integrity": "sha512-0e6nrJgUDN5WwoDRjyh7KV/jbL7WDUhTEWslI64KGpuvD7M6OoPBXYo8Et176O2ENwf52CKVDjXwuvMMNIAzAA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.7.tgz",
+      "integrity": "sha512-7cpZOsHb6nuX6kRCXwWtzBxxJmCVrPcBe/H4q6n1yhWDtqZp/YY05CdFh458V7qUmIKIl70iA5vQ4M9qLPgYcA==",
       "cpu": [
         "arm64"
       ],
@@ -1605,9 +1605,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-arm64-musl": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.6.tgz",
-      "integrity": "sha512-j2yvyv3r2ZEuJG73rWlXFrYrxA7u5+bFSlWTqhsfHZhdb1FKMkklfYRuLtBBdBRLXJ+YMNt9GZT6VTVPJDZnnQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.7.tgz",
+      "integrity": "sha512-Aaqm3rlIr6qV2CdQjkyBceQqUlBpvvhGjKfpdAWhPaur4nN44gmjky88vMqL/1R6pieCdfAtUw4a6IVQ/Dq5VQ==",
       "cpu": [
         "arm64"
       ],
@@ -1625,9 +1625,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-x64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.6.tgz",
-      "integrity": "sha512-5vqldBBnRjIAUmQ88oKli+wPd5vSQaA2AZ2xs+omRlZfeJhC8chlud6DyJV6fVZCC9GI4otK2zSGpfQZx8Kc3A==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.7.tgz",
+      "integrity": "sha512-LSdD1ID4Mdufckk/Oc+IzhyXCFFUVGR+teiToQNzhD3aoEhrJQMKarx/Ea+dInRdBTNmioAL2xT1R2HP9a+HOA==",
       "cpu": [
         "x64"
       ],
@@ -1645,9 +1645,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-x64-musl": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.6.tgz",
-      "integrity": "sha512-29ned+euDKAl+BmCigzGrPykQ/kxTjtsPGV6G3hkImwakHNUnmLRayqmsWKHSwXmBk5xo5m+wqjMbo3G0npJQg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.7.tgz",
+      "integrity": "sha512-0SwXa8XyagGcyCfjYr6vrOCcEJ37VCvO8MV1y0HVjcO+eqH399NgWNvHRUHiA2baiWQeBBBB+B9WyCpdpKSiag==",
       "cpu": [
         "x64"
       ],
@@ -1665,9 +1665,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-win32-arm64-msvc": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.6.tgz",
-      "integrity": "sha512-4b5ASpQlkxSXDYzuM6MYsOc1GnYkqG9CbSA1QzobXm87V/Q+MGPn57eILyacgfbmNNLrO2HQ5hasoLvd2BXaSg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.7.tgz",
+      "integrity": "sha512-99spn9NEABFyn2lCrZL1nfpX06HhDNyWfZvX+e8zvSqV4LP2td2O4jI6St6KjuwVrK0VveNI/vwzJAe3CSGbzQ==",
       "cpu": [
         "arm64"
       ],
@@ -1682,9 +1682,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-win32-x64-msvc": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.6.tgz",
-      "integrity": "sha512-rvGkm4WmVkCKPhvUbLkRtlVhi7EYb8GU8KaqIGJ0dVfNQHDEqnFboaiUHuPN1npFNwB+80Ulzz9AkQ/Q8MswQA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.7.tgz",
+      "integrity": "sha512-Qe5XZLntwivz2fc1POrJnN6vIYGPcNks5q+GHPaCmYUtIBmAx53ME9OC/tLPpfno2jlZAHLy1vLAirkMVzvrwA==",
       "cpu": [
         "x64"
       ],
@@ -2878,9 +2878,9 @@
     },
     "node_modules/vite": {
       "name": "@voidzero-dev/vite-plus-core",
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
-      "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.7.tgz",
+      "integrity": "sha512-zqaBkM1XZ4IHvFJlG2uv7kQF+dqtUcxXSPGyn15BXRfQb101HPpXXe6PHi7YOmZmbQd+hnwNr5+aklXSriZhVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2971,9 +2971,9 @@
       }
     },
     "node_modules/vite-plus": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.6.tgz",
-      "integrity": "sha512-fFX8GLENhtzvnE4NmTPC8INRxjD2kZKcqUW0p7jOdawmHTNZqM5FiieyWOG6WH1a/axu9FCsbUNb918grfzDTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.7.tgz",
+      "integrity": "sha512-4xFo1nDtH/isWBdJaCgmctMiNohbuxa0uiKA/cbpL8jT18Ax73Lt6rK20/LkqPG5a/HpvPNhDCS1QK58pH4txA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2988,7 +2988,7 @@
         "@vitest/snapshot": "4.1.10",
         "@vitest/spy": "4.1.10",
         "@vitest/utils": "4.1.10",
-        "@voidzero-dev/vite-plus-core": "0.2.6",
+        "@voidzero-dev/vite-plus-core": "0.2.7",
         "oxfmt": "=0.60.0",
         "oxlint": "=1.75.0",
         "oxlint-tsgolint": "=7.0.2001",
@@ -3004,14 +3004,14 @@
         "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
       },
       "optionalDependencies": {
-        "@voidzero-dev/vite-plus-darwin-arm64": "0.2.6",
-        "@voidzero-dev/vite-plus-darwin-x64": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.6",
-        "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.6",
-        "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.6"
+        "@voidzero-dev/vite-plus-darwin-arm64": "0.2.7",
+        "@voidzero-dev/vite-plus-darwin-x64": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.7",
+        "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.7",
+        "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.7"
       },
       "peerDependencies": {
         "@vitest/browser-playwright": "4.1.10",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -9,11 +9,11 @@
     "typical": "typical generate types.t --typescript-dir generated"
   },
   "devDependencies": {
-    "@types/node": "^26.1.1",
+    "@types/node": "^26.1.2",
     "typescript": "^7.0.2",
-    "vite-plus": "^0.2.6"
+    "vite-plus": "^0.2.7"
   },
   "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.2.6"
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.2.7"
   }
 }

--- a/integration_tests/typescript_node/package-lock.json
+++ b/integration_tests/typescript_node/package-lock.json
@@ -8,9 +8,9 @@
       "name": "integration-tests",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "typescript": "^7.0.2",
-        "vite-plus": "^0.2.6"
+        "vite-plus": "^0.2.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -954,9 +954,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1458,9 +1458,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-core": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
-      "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.7.tgz",
+      "integrity": "sha512-zqaBkM1XZ4IHvFJlG2uv7kQF+dqtUcxXSPGyn15BXRfQb101HPpXXe6PHi7YOmZmbQd+hnwNr5+aklXSriZhVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1551,9 +1551,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-darwin-arm64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.6.tgz",
-      "integrity": "sha512-QSZWgfqPx5lrIKZ0vwgVRujRqo7gORcc9Oq4fI1UDjKZFgYz9gXVMibSjEqYU3R1webN6FKTOCnzFmrfXchWYw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.7.tgz",
+      "integrity": "sha512-1DsMuysinq4aDiM4212sp5vdDeBPZPdiWwOOZcAl2AVq25hhqDEHdken/PXKHmiXg8M2FGdydpcUtxR5kwdetg==",
       "cpu": [
         "arm64"
       ],
@@ -1568,9 +1568,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-darwin-x64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.6.tgz",
-      "integrity": "sha512-pMQZGCQO0s+akuxbjgh31hOUgrdDndCmfbP7BciJuts436qrBb8KaVzBhNjJQtxD6H8yY21CIOjD8nlrp4eDIw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.7.tgz",
+      "integrity": "sha512-ZYSau3poUyX1qPmxYzFuHtGIE7T0zI8KDY/oAXoDBb5M2HSd+uu0ov6jNETkBphMlcSmQ/lT+FFlAkCBZklpqg==",
       "cpu": [
         "x64"
       ],
@@ -1585,9 +1585,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-arm64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.6.tgz",
-      "integrity": "sha512-0e6nrJgUDN5WwoDRjyh7KV/jbL7WDUhTEWslI64KGpuvD7M6OoPBXYo8Et176O2ENwf52CKVDjXwuvMMNIAzAA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.7.tgz",
+      "integrity": "sha512-7cpZOsHb6nuX6kRCXwWtzBxxJmCVrPcBe/H4q6n1yhWDtqZp/YY05CdFh458V7qUmIKIl70iA5vQ4M9qLPgYcA==",
       "cpu": [
         "arm64"
       ],
@@ -1605,9 +1605,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-arm64-musl": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.6.tgz",
-      "integrity": "sha512-j2yvyv3r2ZEuJG73rWlXFrYrxA7u5+bFSlWTqhsfHZhdb1FKMkklfYRuLtBBdBRLXJ+YMNt9GZT6VTVPJDZnnQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.7.tgz",
+      "integrity": "sha512-Aaqm3rlIr6qV2CdQjkyBceQqUlBpvvhGjKfpdAWhPaur4nN44gmjky88vMqL/1R6pieCdfAtUw4a6IVQ/Dq5VQ==",
       "cpu": [
         "arm64"
       ],
@@ -1625,9 +1625,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-x64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.6.tgz",
-      "integrity": "sha512-5vqldBBnRjIAUmQ88oKli+wPd5vSQaA2AZ2xs+omRlZfeJhC8chlud6DyJV6fVZCC9GI4otK2zSGpfQZx8Kc3A==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.7.tgz",
+      "integrity": "sha512-LSdD1ID4Mdufckk/Oc+IzhyXCFFUVGR+teiToQNzhD3aoEhrJQMKarx/Ea+dInRdBTNmioAL2xT1R2HP9a+HOA==",
       "cpu": [
         "x64"
       ],
@@ -1645,9 +1645,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-x64-musl": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.6.tgz",
-      "integrity": "sha512-29ned+euDKAl+BmCigzGrPykQ/kxTjtsPGV6G3hkImwakHNUnmLRayqmsWKHSwXmBk5xo5m+wqjMbo3G0npJQg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.7.tgz",
+      "integrity": "sha512-0SwXa8XyagGcyCfjYr6vrOCcEJ37VCvO8MV1y0HVjcO+eqH399NgWNvHRUHiA2baiWQeBBBB+B9WyCpdpKSiag==",
       "cpu": [
         "x64"
       ],
@@ -1665,9 +1665,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-win32-arm64-msvc": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.6.tgz",
-      "integrity": "sha512-4b5ASpQlkxSXDYzuM6MYsOc1GnYkqG9CbSA1QzobXm87V/Q+MGPn57eILyacgfbmNNLrO2HQ5hasoLvd2BXaSg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.7.tgz",
+      "integrity": "sha512-99spn9NEABFyn2lCrZL1nfpX06HhDNyWfZvX+e8zvSqV4LP2td2O4jI6St6KjuwVrK0VveNI/vwzJAe3CSGbzQ==",
       "cpu": [
         "arm64"
       ],
@@ -1682,9 +1682,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-win32-x64-msvc": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.6.tgz",
-      "integrity": "sha512-rvGkm4WmVkCKPhvUbLkRtlVhi7EYb8GU8KaqIGJ0dVfNQHDEqnFboaiUHuPN1npFNwB+80Ulzz9AkQ/Q8MswQA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.7.tgz",
+      "integrity": "sha512-Qe5XZLntwivz2fc1POrJnN6vIYGPcNks5q+GHPaCmYUtIBmAx53ME9OC/tLPpfno2jlZAHLy1vLAirkMVzvrwA==",
       "cpu": [
         "x64"
       ],
@@ -2878,9 +2878,9 @@
     },
     "node_modules/vite": {
       "name": "@voidzero-dev/vite-plus-core",
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
-      "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.7.tgz",
+      "integrity": "sha512-zqaBkM1XZ4IHvFJlG2uv7kQF+dqtUcxXSPGyn15BXRfQb101HPpXXe6PHi7YOmZmbQd+hnwNr5+aklXSriZhVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2971,9 +2971,9 @@
       }
     },
     "node_modules/vite-plus": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.6.tgz",
-      "integrity": "sha512-fFX8GLENhtzvnE4NmTPC8INRxjD2kZKcqUW0p7jOdawmHTNZqM5FiieyWOG6WH1a/axu9FCsbUNb918grfzDTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.7.tgz",
+      "integrity": "sha512-4xFo1nDtH/isWBdJaCgmctMiNohbuxa0uiKA/cbpL8jT18Ax73Lt6rK20/LkqPG5a/HpvPNhDCS1QK58pH4txA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2988,7 +2988,7 @@
         "@vitest/snapshot": "4.1.10",
         "@vitest/spy": "4.1.10",
         "@vitest/utils": "4.1.10",
-        "@voidzero-dev/vite-plus-core": "0.2.6",
+        "@voidzero-dev/vite-plus-core": "0.2.7",
         "oxfmt": "=0.60.0",
         "oxlint": "=1.75.0",
         "oxlint-tsgolint": "=7.0.2001",
@@ -3004,14 +3004,14 @@
         "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
       },
       "optionalDependencies": {
-        "@voidzero-dev/vite-plus-darwin-arm64": "0.2.6",
-        "@voidzero-dev/vite-plus-darwin-x64": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.6",
-        "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.6",
-        "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.6"
+        "@voidzero-dev/vite-plus-darwin-arm64": "0.2.7",
+        "@voidzero-dev/vite-plus-darwin-x64": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.7",
+        "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.7",
+        "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.7"
       },
       "peerDependencies": {
         "@vitest/browser-playwright": "4.1.10",

--- a/integration_tests/typescript_node/package.json
+++ b/integration_tests/typescript_node/package.json
@@ -9,11 +9,11 @@
     "typical": "(cd ../.. && cargo run -- generate integration_tests/types/types.t --typescript-dir integration_tests/typescript_node/generated)"
   },
   "devDependencies": {
-    "@types/node": "^26.1.1",
+    "@types/node": "^26.1.2",
     "typescript": "^7.0.2",
-    "vite-plus": "^0.2.6"
+    "vite-plus": "^0.2.7"
   },
   "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.2.6"
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.2.7"
   }
 }

--- a/integration_tests/typescript_web/package-lock.json
+++ b/integration_tests/typescript_web/package-lock.json
@@ -8,14 +8,14 @@
       "name": "integration-tests",
       "version": "1.0.0",
       "dependencies": {
-        "js-sha256": "^0.12.0",
-        "lodash": "4.18.1"
+        "js-sha256": "^1.0.0",
+        "lodash": "^4.18.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.62.0",
-        "@types/lodash": "4.17.24",
+        "@playwright/test": "^1.62.1",
+        "@types/lodash": "^4.17.25",
         "typescript": "^7.0.2",
-        "vite-plus": "^0.2.6"
+        "vite-plus": "^0.2.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -879,13 +879,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
-      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -975,9 +975,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+      "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1476,9 +1476,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-core": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
-      "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.7.tgz",
+      "integrity": "sha512-zqaBkM1XZ4IHvFJlG2uv7kQF+dqtUcxXSPGyn15BXRfQb101HPpXXe6PHi7YOmZmbQd+hnwNr5+aklXSriZhVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1569,9 +1569,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-darwin-arm64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.6.tgz",
-      "integrity": "sha512-QSZWgfqPx5lrIKZ0vwgVRujRqo7gORcc9Oq4fI1UDjKZFgYz9gXVMibSjEqYU3R1webN6FKTOCnzFmrfXchWYw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-arm64/-/vite-plus-darwin-arm64-0.2.7.tgz",
+      "integrity": "sha512-1DsMuysinq4aDiM4212sp5vdDeBPZPdiWwOOZcAl2AVq25hhqDEHdken/PXKHmiXg8M2FGdydpcUtxR5kwdetg==",
       "cpu": [
         "arm64"
       ],
@@ -1586,9 +1586,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-darwin-x64": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.6.tgz",
-      "integrity": "sha512-pMQZGCQO0s+akuxbjgh31hOUgrdDndCmfbP7BciJuts436qrBb8KaVzBhNjJQtxD6H8yY21CIOjD8nlrp4eDIw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-darwin-x64/-/vite-plus-darwin-x64-0.2.7.tgz",
+      "integrity": "sha512-ZYSau3poUyX1qPmxYzFuHtGIE7T0zI8KDY/oAXoDBb5M2HSd+uu0ov6jNETkBphMlcSmQ/lT+FFlAkCBZklpqg==",
       "cpu": [
         "x64"
       ],
@@ -1603,9 +1603,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-arm64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.6.tgz",
-      "integrity": "sha512-0e6nrJgUDN5WwoDRjyh7KV/jbL7WDUhTEWslI64KGpuvD7M6OoPBXYo8Et176O2ENwf52CKVDjXwuvMMNIAzAA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-gnu/-/vite-plus-linux-arm64-gnu-0.2.7.tgz",
+      "integrity": "sha512-7cpZOsHb6nuX6kRCXwWtzBxxJmCVrPcBe/H4q6n1yhWDtqZp/YY05CdFh458V7qUmIKIl70iA5vQ4M9qLPgYcA==",
       "cpu": [
         "arm64"
       ],
@@ -1623,9 +1623,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-arm64-musl": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.6.tgz",
-      "integrity": "sha512-j2yvyv3r2ZEuJG73rWlXFrYrxA7u5+bFSlWTqhsfHZhdb1FKMkklfYRuLtBBdBRLXJ+YMNt9GZT6VTVPJDZnnQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-arm64-musl/-/vite-plus-linux-arm64-musl-0.2.7.tgz",
+      "integrity": "sha512-Aaqm3rlIr6qV2CdQjkyBceQqUlBpvvhGjKfpdAWhPaur4nN44gmjky88vMqL/1R6pieCdfAtUw4a6IVQ/Dq5VQ==",
       "cpu": [
         "arm64"
       ],
@@ -1643,9 +1643,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-x64-gnu": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.6.tgz",
-      "integrity": "sha512-5vqldBBnRjIAUmQ88oKli+wPd5vSQaA2AZ2xs+omRlZfeJhC8chlud6DyJV6fVZCC9GI4otK2zSGpfQZx8Kc3A==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-gnu/-/vite-plus-linux-x64-gnu-0.2.7.tgz",
+      "integrity": "sha512-LSdD1ID4Mdufckk/Oc+IzhyXCFFUVGR+teiToQNzhD3aoEhrJQMKarx/Ea+dInRdBTNmioAL2xT1R2HP9a+HOA==",
       "cpu": [
         "x64"
       ],
@@ -1663,9 +1663,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-linux-x64-musl": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.6.tgz",
-      "integrity": "sha512-29ned+euDKAl+BmCigzGrPykQ/kxTjtsPGV6G3hkImwakHNUnmLRayqmsWKHSwXmBk5xo5m+wqjMbo3G0npJQg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-linux-x64-musl/-/vite-plus-linux-x64-musl-0.2.7.tgz",
+      "integrity": "sha512-0SwXa8XyagGcyCfjYr6vrOCcEJ37VCvO8MV1y0HVjcO+eqH399NgWNvHRUHiA2baiWQeBBBB+B9WyCpdpKSiag==",
       "cpu": [
         "x64"
       ],
@@ -1683,9 +1683,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-win32-arm64-msvc": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.6.tgz",
-      "integrity": "sha512-4b5ASpQlkxSXDYzuM6MYsOc1GnYkqG9CbSA1QzobXm87V/Q+MGPn57eILyacgfbmNNLrO2HQ5hasoLvd2BXaSg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-arm64-msvc/-/vite-plus-win32-arm64-msvc-0.2.7.tgz",
+      "integrity": "sha512-99spn9NEABFyn2lCrZL1nfpX06HhDNyWfZvX+e8zvSqV4LP2td2O4jI6St6KjuwVrK0VveNI/vwzJAe3CSGbzQ==",
       "cpu": [
         "arm64"
       ],
@@ -1700,9 +1700,9 @@
       }
     },
     "node_modules/@voidzero-dev/vite-plus-win32-x64-msvc": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.6.tgz",
-      "integrity": "sha512-rvGkm4WmVkCKPhvUbLkRtlVhi7EYb8GU8KaqIGJ0dVfNQHDEqnFboaiUHuPN1npFNwB+80Ulzz9AkQ/Q8MswQA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-win32-x64-msvc/-/vite-plus-win32-x64-msvc-0.2.7.tgz",
+      "integrity": "sha512-Qe5XZLntwivz2fc1POrJnN6vIYGPcNks5q+GHPaCmYUtIBmAx53ME9OC/tLPpfno2jlZAHLy1vLAirkMVzvrwA==",
       "cpu": [
         "x64"
       ],
@@ -2193,9 +2193,9 @@
       }
     },
     "node_modules/js-sha256": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.12.0.tgz",
-      "integrity": "sha512-P2IyTRMIHCkLD9clcQST8wGP/wqOXjvDD7E3onloE/5LSQGscyrmk2Loa069YsdtLfQWN1EnMDiaomAs9AfP4w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-1.0.0.tgz",
+      "integrity": "sha512-Bqxf6ENUzYIMzuELCmRNrJOVbjKH1oMgbfYJBKVr/W1Xf9fazpahqCbb24v1pR7XV1isuqhM+w9KWpK7zCyUQw==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -2694,13 +2694,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
-      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2713,9 +2713,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
-      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2948,9 +2948,9 @@
     },
     "node_modules/vite": {
       "name": "@voidzero-dev/vite-plus-core",
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.6.tgz",
-      "integrity": "sha512-vqDuuLJWS2JHWkFO7r8Z6AehtKnurpnYtw2XEQtjIfwE2GgSAO3zJdPIeaEZiovS6CqfQa+iOMn3kzVzeTSpTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@voidzero-dev/vite-plus-core/-/vite-plus-core-0.2.7.tgz",
+      "integrity": "sha512-zqaBkM1XZ4IHvFJlG2uv7kQF+dqtUcxXSPGyn15BXRfQb101HPpXXe6PHi7YOmZmbQd+hnwNr5+aklXSriZhVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3041,9 +3041,9 @@
       }
     },
     "node_modules/vite-plus": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.6.tgz",
-      "integrity": "sha512-fFX8GLENhtzvnE4NmTPC8INRxjD2kZKcqUW0p7jOdawmHTNZqM5FiieyWOG6WH1a/axu9FCsbUNb918grfzDTw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/vite-plus/-/vite-plus-0.2.7.tgz",
+      "integrity": "sha512-4xFo1nDtH/isWBdJaCgmctMiNohbuxa0uiKA/cbpL8jT18Ax73Lt6rK20/LkqPG5a/HpvPNhDCS1QK58pH4txA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3058,7 +3058,7 @@
         "@vitest/snapshot": "4.1.10",
         "@vitest/spy": "4.1.10",
         "@vitest/utils": "4.1.10",
-        "@voidzero-dev/vite-plus-core": "0.2.6",
+        "@voidzero-dev/vite-plus-core": "0.2.7",
         "oxfmt": "=0.60.0",
         "oxlint": "=1.75.0",
         "oxlint-tsgolint": "=7.0.2001",
@@ -3074,14 +3074,14 @@
         "node": "^20.19.0 || ^22.18.0 || >=24.11.0"
       },
       "optionalDependencies": {
-        "@voidzero-dev/vite-plus-darwin-arm64": "0.2.6",
-        "@voidzero-dev/vite-plus-darwin-x64": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.6",
-        "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.6",
-        "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.6",
-        "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.6"
+        "@voidzero-dev/vite-plus-darwin-arm64": "0.2.7",
+        "@voidzero-dev/vite-plus-darwin-x64": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.7",
+        "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.7",
+        "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.7",
+        "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.7"
       },
       "peerDependencies": {
         "@vitest/browser-playwright": "4.1.10",

--- a/integration_tests/typescript_web/package.json
+++ b/integration_tests/typescript_web/package.json
@@ -12,16 +12,16 @@
     "serve": "npm run typical && tsc --project tsconfig.json && vp dev"
   },
   "dependencies": {
-    "js-sha256": "^0.12.0",
-    "lodash": "4.18.1"
+    "js-sha256": "^1.0.0",
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.62.0",
-    "@types/lodash": "4.17.24",
+    "@playwright/test": "^1.62.1",
+    "@types/lodash": "^4.17.25",
     "typescript": "^7.0.2",
-    "vite-plus": "^0.2.6"
+    "vite-plus": "^0.2.7"
   },
   "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@^0.2.6"
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.2.7"
   }
 }


### PR DESCRIPTION
Update Rust and TypeScript dependencies, including clap 4.6.5, clap_complete 4.6.8, Vite Plus 0.2.7, and js-sha256 1.0.0; discard exact npm pins; and update docker/login-action from 4.5.1 to 4.6.0. Rust and the 2026 copyright notice were already current.

**Status:** Ready

**Fixes:** N/A